### PR TITLE
Fix prerender runtime performance regressions

### DIFF
--- a/src/routes/posts/[id]/+page.svelte
+++ b/src/routes/posts/[id]/+page.svelte
@@ -57,12 +57,12 @@
         return `rgb(${Math.round(dominant.r / dominant.count)} ${Math.round(dominant.g / dominant.count)} ${Math.round(dominant.b / dominant.count)})`;
     }
 
-    function setImageBackground(url: string, postId: string) {
+    function setImageBackground(url: string) {
+        if (imageBackgrounds[url]) return;
+
         const image = new Image();
         image.crossOrigin = 'anonymous';
         image.onload = () => {
-            if (data.id !== postId) return;
-
             try {
                 const color = getDominantColor(image);
                 if (!color) return;
@@ -72,19 +72,16 @@
             }
         };
         image.onerror = () => {
-            if (data.id !== postId) return;
             imageBackgrounds = { ...imageBackgrounds, [url]: 'var(--color-surface)' };
         };
         image.src = url;
     }
 
     $effect(() => {
-        const postId = data.id;
-        const imageUrls = [...data.post.url];
+        if (!data.id) return;
 
         showNsfw = false;
         imageBackgrounds = {};
-        imageUrls.forEach(url => setImageBackground(url, postId));
     });
 </script>
 
@@ -108,7 +105,9 @@
                     src={url}
                     alt={`Translated artwork page ${index + 1}`}
                     loading={index === 0 ? 'eager' : 'lazy'}
+                    fetchpriority={index === 0 ? 'high' : 'auto'}
                     decoding="async"
+                    onload={() => setImageBackground(url)}
                 />
             </figure>
         {/each}

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -79,11 +79,6 @@ async function matchNavigation(request: Request): Promise<Response | undefined> 
         ?? await cache.match(request, { ignoreSearch: true });
 }
 
-async function matchData(request: Request): Promise<Response | undefined> {
-    const cache = await caches.open(cacheName);
-    return await cache.match(request);
-}
-
 worker.addEventListener('install', event => {
     event.waitUntil(
         caches.open(cacheName)
@@ -113,7 +108,7 @@ worker.addEventListener('fetch', event => {
     }
 
     if (isDataRequest(url)) {
-        event.respondWith(networkFirst(event, () => matchData(event.request)));
+        event.respondWith(cacheFirst(event));
         return;
     }
 


### PR DESCRIPTION
This keeps the prerender architecture while removing the two runtime regressions identified after the refactor.

Changes:
- preserve lazy loading by moving dominant-color work back behind each artwork image's `load` event instead of eagerly starting color-analysis requests for every image during hydration
- prioritize only the first artwork image with `fetchpriority="high"`
- serve cached SvelteKit `__data.json` responses cache-first so repeat client-side navigation does not wait on the network
- keep document navigation network-first for fresh HTML with offline fallback

The existing CI workflow will run the verification suite, production build checks, and Playwright coverage on this PR.