### PR TITLE
Serve responsive Reddit images

### DIFF
--- a/scripts/generateDerivedData.ts
+++ b/scripts/generateDerivedData.ts
@@ -12,7 +12,8 @@ import type {
     HomePost,
     ImageDimensions,
     Post,
-    RelatedPost
+    RelatedPost,
+    ResponsiveImageSource
 } from '../src/types/data.ts';
 import { printValidationResult, validateData } from './validateData.ts';
 
@@ -26,9 +27,43 @@ interface GenerateOptions {
     includeImageDimensions?: boolean;
 }
 
+interface RedditPreviewSource {
+    url?: string;
+    u?: string;
+    width?: number;
+    x?: number;
+}
+
+interface RedditMediaMetadata {
+    p?: RedditPreviewSource[];
+    s?: RedditPreviewSource;
+}
+
+interface RedditPostMetadata {
+    id?: string;
+    media_metadata?: Record<string, RedditMediaMetadata>;
+    preview?: {
+        images?: Array<{
+            source?: RedditPreviewSource;
+            resolutions?: RedditPreviewSource[];
+        }>;
+    };
+}
+
+interface RedditInfoResponse {
+    data?: {
+        children?: Array<{
+            data?: RedditPostMetadata;
+        }>;
+    };
+}
+
 const imageMetadataConcurrency = 16;
 const imageHeaderBytes = 64 * 1024;
 const imageRequestTimeoutMs = 8_000;
+const redditBatchSize = 50;
+const redditMetadataConcurrency = 2;
+const redditRequestTimeoutMs = 10_000;
 
 const readJson = <T>(filePath: string): T => JSON.parse(fs.readFileSync(filePath, 'utf8')) as T;
 const writeJson = (filePath: string, value: unknown): void => {
@@ -225,6 +260,115 @@ const resolveImageDimensions = async (posts: Post[]): Promise<Map<string, ImageD
     return result;
 };
 
+const decodeRedditUrl = (value: string): string => value.replaceAll('&amp;', '&');
+
+const imageStem = (value: string): string => {
+    try {
+        const filename = new URL(value).pathname.split('/').at(-1) ?? '';
+        return filename.replace(/\.[^.]+$/, '');
+    } catch {
+        return '';
+    }
+};
+
+const normalizeResponsiveSource = (source: RedditPreviewSource | undefined): ResponsiveImageSource | null => {
+    const rawUrl = source?.url ?? source?.u;
+    const width = source?.width ?? source?.x;
+    if (!rawUrl || !width || width <= 0) return null;
+
+    const url = decodeRedditUrl(rawUrl);
+    try {
+        const parsed = new URL(url);
+        if (parsed.protocol !== 'https:' || !['preview.redd.it', 'i.redd.it'].includes(parsed.hostname)) return null;
+        return { url: parsed.toString(), width };
+    } catch {
+        return null;
+    }
+};
+
+const normalizeResponsiveSources = (sources: Array<RedditPreviewSource | undefined>): ResponsiveImageSource[] => {
+    const byWidth = new Map<number, ResponsiveImageSource>();
+    for (const source of sources) {
+        const normalized = normalizeResponsiveSource(source);
+        if (normalized) byWidth.set(normalized.width, normalized);
+    }
+    return [...byWidth.values()].sort((a, b) => a.width - b.width);
+};
+
+const fetchRedditMetadataBatch = async (postIds: string[]): Promise<RedditPostMetadata[]> => {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), redditRequestTimeoutMs);
+    const fullnames = postIds.map(id => `t3_${id}`).join(',');
+
+    try {
+        const response = await fetch(`https://www.reddit.com/api/info.json?id=${encodeURIComponent(fullnames)}&raw_json=1`, {
+            headers: {
+                Accept: 'application/json',
+                'User-Agent': 'touhou-translations-build/1.0'
+            },
+            signal: controller.signal
+        });
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const payload = await response.json() as RedditInfoResponse;
+        return payload.data?.children?.map(child => child.data).filter((post): post is RedditPostMetadata => Boolean(post)) ?? [];
+    } finally {
+        clearTimeout(timeout);
+    }
+};
+
+const resolveResponsiveImageSources = async (posts: Post[]): Promise<Map<string, ResponsiveImageSource[]>> => {
+    const postsById = new Map<string, Post>();
+    for (const post of posts) {
+        const id = extractRedditId(post.reddit);
+        if (id) postsById.set(id, post);
+    }
+
+    const ids = [...postsById.keys()];
+    const batches = Array.from(
+        { length: Math.ceil(ids.length / redditBatchSize) },
+        (_, index) => ids.slice(index * redditBatchSize, (index + 1) * redditBatchSize)
+    );
+
+    let failedBatches = 0;
+    const metadataBatches = await mapConcurrent(batches, redditMetadataConcurrency, async batch => {
+        try {
+            return await fetchRedditMetadataBatch(batch);
+        } catch (error) {
+            failedBatches += 1;
+            const message = error instanceof Error ? error.message : String(error);
+            console.warn(`Could not resolve Reddit responsive metadata for a batch of ${batch.length} posts: ${message}`);
+            return [];
+        }
+    });
+
+    const result = new Map<string, ResponsiveImageSource[]>();
+    for (const metadata of metadataBatches.flat()) {
+        if (!metadata.id) continue;
+        const post = postsById.get(metadata.id);
+        if (!post) continue;
+
+        const mediaByStem = new Map<string, RedditMediaMetadata>();
+        for (const [mediaId, media] of Object.entries(metadata.media_metadata ?? {})) {
+            mediaByStem.set(mediaId, media);
+        }
+
+        post.url.forEach((url, index) => {
+            const media = mediaByStem.get(imageStem(url));
+            const previewImage = metadata.preview?.images?.[index] ?? (index === 0 ? metadata.preview?.images?.[0] : undefined);
+            const sources = media
+                ? normalizeResponsiveSources([...(media.p ?? []), media.s])
+                : normalizeResponsiveSources([...(previewImage?.resolutions ?? []), previewImage?.source]);
+            if (sources.length > 0) result.set(url, sources);
+        });
+    }
+
+    console.log(
+        `Resolved responsive sources for ${result.size}/${new Set(posts.flatMap(post => post.url)).size} artwork images`
+        + `${failedBatches ? ` (${failedBatches} Reddit metadata batches unavailable)` : ''}.`
+    );
+    return result;
+};
+
 export const generateDerivedData = async (
     rootDir = process.cwd(),
     options: GenerateOptions = {}
@@ -244,9 +388,12 @@ export const generateDerivedData = async (
     const artistsRaw = readJson<ArtistRaw[]>(path.join(rootDir, 'data', 'artists.json'));
     const charactersRaw = readJson<CharacterRaw[]>(path.join(rootDir, 'data', 'characters.json'));
     const derived = buildDerivedData(posts, artistsRaw, charactersRaw);
-    const imageDimensions = options.includeImageDimensions
-        ? await resolveImageDimensions(posts)
-        : new Map<string, ImageDimensions>();
+    const [imageDimensions, responsiveImageSources] = options.includeImageDimensions
+        ? await Promise.all([
+            resolveImageDimensions(posts),
+            resolveResponsiveImageSources(posts)
+        ])
+        : [new Map<string, ImageDimensions>(), new Map<string, ResponsiveImageSource[]>()];
 
     fs.rmSync(generatedDir, { recursive: true, force: true });
     fs.mkdirSync(generatedPostsDir, { recursive: true });
@@ -267,9 +414,10 @@ export const generateDerivedData = async (
         const chunkPosts = chunks.get(chunk) ?? [];
         const { desc, ...postWithoutDescription } = post;
         const dimensions = post.url.map(url => imageDimensions.get(url) ?? null);
+        const imageSources = post.url.map(url => responsiveImageSources.get(url) ?? []);
         chunkPosts.push({
             ...postWithoutDescription,
-            ...(options.includeImageDimensions ? { imageDimensions: dimensions } : {}),
+            ...(options.includeImageDimensions ? { imageDimensions: dimensions, imageSources } : {}),
             htmlDescription: renderMarkdown(desc),
             metadataDescription: markdownExcerpt(desc)
         });
@@ -279,12 +427,24 @@ export const generateDerivedData = async (
         postIndex[id] = { chunk, ...adjacent };
         postIds.push(id);
 
-        const summary: HomePost = { id, img: post.url[0], nsfw: post.nsfw, date: post.date };
+        const firstImageSources = responsiveImageSources.get(post.url[0]) ?? [];
+        const summary: HomePost = {
+            id,
+            img: post.url[0],
+            ...(firstImageSources.length ? { imgSources: firstImageSources } : {}),
+            nsfw: post.nsfw,
+            date: post.date
+        };
         homePosts.push(summary);
         galleryPosts.push({ ...summary, artistId: post.artistId, characterIds: post.characterIds });
 
         const related = artistPosts[post.artistId] ?? [];
-        related.push({ id, img: post.url[0], nsfw: post.nsfw });
+        related.push({
+            id,
+            img: post.url[0],
+            ...(firstImageSources.length ? { imgSources: firstImageSources } : {}),
+            nsfw: post.nsfw
+        });
         artistPosts[post.artistId] = related;
     }
 

--- a/src/lib/components/gallery/GalleryGrid.svelte
+++ b/src/lib/components/gallery/GalleryGrid.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { resolve } from '$app/paths';
     import type { GalleryPost } from '../../../types/data';
+    import { responsiveSrcset } from '../../../utils/responsiveImage';
 
     interface Props {
         posts: GalleryPost[];
@@ -12,7 +13,15 @@
 <div class="grid">
     {#each posts as post (post.id)}
         <a class="tile" href={resolve('/posts/[id]', { id: post.id })} aria-label={`View post ${post.id}`}>
-            <img class:nsfw={post.nsfw} src={post.img} alt="" loading="lazy" decoding="async" />
+            <img
+                class:nsfw={post.nsfw}
+                src={post.img}
+                srcset={responsiveSrcset(post.imgSources, post.img)}
+                sizes="(max-width: 700px) 50vw, (max-width: 1180px) 25vw, 17vw"
+                alt=""
+                loading="lazy"
+                decoding="async"
+            />
             {#if post.nsfw}<span>NSFW</span>{/if}
         </a>
     {/each}

--- a/src/lib/components/home/DailyPost.svelte
+++ b/src/lib/components/home/DailyPost.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
     import { resolve } from '$app/paths';
+    import type { ResponsiveImageSource } from '../../../types/data';
+    import { responsiveSrcset } from '../../../utils/responsiveImage';
 
     interface DailyPost {
         id: string;
         img: string;
+        imgSources?: ResponsiveImageSource[];
         nsfw: boolean;
     }
 
@@ -18,7 +21,15 @@
     <h2>Post of the Day</h2>
     {#if post}
         <a class="daily-link" href={resolve('/posts/[id]', { id: post.id })}>
-            <img class:nsfw={post.nsfw} src={post.img} alt="Post of the day" loading="lazy" decoding="async" />
+            <img
+                class:nsfw={post.nsfw}
+                src={post.img}
+                srcset={responsiveSrcset(post.imgSources, post.img)}
+                sizes="(max-width: 900px) calc(100vw - 2rem), min(40vw, 500px)"
+                alt="Post of the day"
+                loading="lazy"
+                decoding="async"
+            />
         </a>
     {/if}
 </section>

--- a/src/routes/posts/[id]/+page.svelte
+++ b/src/routes/posts/[id]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { asset, resolve } from '$app/paths';
+    import { responsiveSrcset } from '../../../utils/responsiveImage';
     import { absoluteSiteUrl } from '../../../utils/siteMetadata';
     import type { PageData } from './$types';
 
@@ -100,10 +101,13 @@
     <div class="images">
         {#each data.post.url as url, index (url)}
             {@const dimensions = data.post.imageDimensions?.[index]}
+            {@const sources = data.post.imageSources?.[index]}
             <figure style:background-color={imageBackgrounds[url] ?? undefined}>
                 <img
                     class:nsfw={data.post.nsfw && !showNsfw}
                     src={url}
+                    srcset={responsiveSrcset(sources, url, dimensions?.width)}
+                    sizes="(max-width: 900px) calc(100vw - 2rem), min(1050px, calc(100vw - 490px))"
                     alt={`Translated artwork page ${index + 1}`}
                     width={dimensions?.width}
                     height={dimensions?.height}
@@ -176,7 +180,15 @@
                             href={resolve('/posts/[id]', { id: item.id })}
                             aria-label={`View another translated work by ${artistName}`}
                         >
-                            <img class:nsfw={item.nsfw && !showNsfw} src={item.img} alt="" loading="lazy" decoding="async" />
+                            <img
+                                class:nsfw={item.nsfw && !showNsfw}
+                                src={item.img}
+                                srcset={responsiveSrcset(item.imgSources, item.img)}
+                                sizes="210px"
+                                alt=""
+                                loading="lazy"
+                                decoding="async"
+                            />
                         </a>
                     {/each}
                 </div>

--- a/src/routes/posts/[id]/+page.svelte
+++ b/src/routes/posts/[id]/+page.svelte
@@ -5,7 +5,6 @@
     import type { PageData } from './$types';
 
     let { data }: { data: PageData } = $props();
-    let imageBackgrounds = $state<Record<string, string>>({});
     let showNsfw = $state(false);
 
     const artistName = $derived(data.artist?.name ?? data.post.artistId);
@@ -22,67 +21,9 @@
         return `${resolve('/gallery')}?artist=${encodeURIComponent(artistId)}`;
     }
 
-    function getDominantColor(image: HTMLImageElement): string | null {
-        const canvas = document.createElement('canvas');
-        const context = canvas.getContext('2d', { willReadFrequently: true });
-        if (!context || image.naturalWidth === 0 || image.naturalHeight === 0) return null;
-
-        const sampleSize = 32;
-        const scale = Math.min(sampleSize / image.naturalWidth, sampleSize / image.naturalHeight, 1);
-        canvas.width = Math.max(1, Math.round(image.naturalWidth * scale));
-        canvas.height = Math.max(1, Math.round(image.naturalHeight * scale));
-        context.drawImage(image, 0, 0, canvas.width, canvas.height);
-
-        const pixels = context.getImageData(0, 0, canvas.width, canvas.height).data;
-        const buckets = new Map<string, { count: number; r: number; g: number; b: number }>();
-
-        for (let index = 0; index < pixels.length; index += 4) {
-            const alpha = pixels[index + 3];
-            if (alpha < 128) continue;
-
-            const r = pixels[index];
-            const g = pixels[index + 1];
-            const b = pixels[index + 2];
-            const key = `${r >> 4},${g >> 4},${b >> 4}`;
-            const bucket = buckets.get(key) ?? { count: 0, r: 0, g: 0, b: 0 };
-            bucket.count += 1;
-            bucket.r += r;
-            bucket.g += g;
-            bucket.b += b;
-            buckets.set(key, bucket);
-        }
-
-        const dominant = [...buckets.values()].sort((a, b) => b.count - a.count)[0];
-        if (!dominant) return null;
-
-        return `rgb(${Math.round(dominant.r / dominant.count)} ${Math.round(dominant.g / dominant.count)} ${Math.round(dominant.b / dominant.count)})`;
-    }
-
-    function setImageBackground(url: string) {
-        if (imageBackgrounds[url]) return;
-
-        const image = new Image();
-        image.crossOrigin = 'anonymous';
-        image.onload = () => {
-            try {
-                const color = getDominantColor(image);
-                if (!color) return;
-                imageBackgrounds = { ...imageBackgrounds, [url]: color };
-            } catch {
-                imageBackgrounds = { ...imageBackgrounds, [url]: 'var(--color-surface)' };
-            }
-        };
-        image.onerror = () => {
-            imageBackgrounds = { ...imageBackgrounds, [url]: 'var(--color-surface)' };
-        };
-        image.src = url;
-    }
-
     $effect(() => {
         if (!data.id) return;
-
         showNsfw = false;
-        imageBackgrounds = {};
     });
 </script>
 
@@ -102,7 +43,7 @@
         {#each data.post.url as url, index (url)}
             {@const dimensions = data.post.imageDimensions?.[index]}
             {@const sources = data.post.imageSources?.[index]}
-            <figure style:background-color={imageBackgrounds[url] ?? undefined}>
+            <figure>
                 <img
                     class:nsfw={data.post.nsfw && !showNsfw}
                     src={url}
@@ -114,7 +55,6 @@
                     loading={index === 0 ? 'eager' : 'lazy'}
                     fetchpriority={index === 0 ? 'high' : 'auto'}
                     decoding="async"
-                    onload={() => setImageBackground(url)}
                 />
             </figure>
         {/each}

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -9,9 +9,15 @@ export interface Post {
     nsfw: boolean;
 }
 
+export interface ResponsiveImageSource {
+    url: string;
+    width: number;
+}
+
 export interface HomePost {
     id: string;
     img: string;
+    imgSources?: ResponsiveImageSource[];
     nsfw: boolean;
     date: number;
 }
@@ -24,6 +30,7 @@ export interface GalleryPost extends HomePost {
 export interface RelatedPost {
     id: string;
     img: string;
+    imgSources?: ResponsiveImageSource[];
     nsfw: boolean;
 }
 
@@ -34,6 +41,7 @@ export interface ImageDimensions {
 
 export interface GeneratedPost extends Omit<Post, 'desc'> {
     imageDimensions?: Array<ImageDimensions | null>;
+    imageSources?: ResponsiveImageSource[][];
     htmlDescription: string;
     metadataDescription: string;
 }

--- a/src/utils/responsiveImage.test.ts
+++ b/src/utils/responsiveImage.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { responsiveSrcset } from './responsiveImage';
+
+describe('responsiveSrcset', () => {
+    it('sorts responsive candidates and includes the original fallback width', () => {
+        expect(responsiveSrcset([
+            { url: 'https://preview.redd.it/image.png?width=640', width: 640 },
+            { url: 'https://preview.redd.it/image.png?width=320', width: 320 }
+        ], 'https://i.redd.it/image.png', 1600)).toBe(
+            'https://preview.redd.it/image.png?width=320 320w, '
+            + 'https://preview.redd.it/image.png?width=640 640w, '
+            + 'https://i.redd.it/image.png 1600w'
+        );
+    });
+
+    it('omits srcset when only the fallback candidate is available', () => {
+        expect(responsiveSrcset(undefined, 'https://i.redd.it/image.png', 1600)).toBeUndefined();
+    });
+});

--- a/src/utils/responsiveImage.ts
+++ b/src/utils/responsiveImage.ts
@@ -1,0 +1,19 @@
+import type { ResponsiveImageSource } from '../types/data';
+
+export const responsiveSrcset = (
+    sources: ResponsiveImageSource[] | undefined,
+    fallbackUrl: string,
+    fallbackWidth?: number
+): string | undefined => {
+    const candidates = new Map<number, string>();
+    for (const source of sources ?? []) {
+        if (source.width > 0 && source.url) candidates.set(source.width, source.url);
+    }
+    if (fallbackWidth && fallbackWidth > 0) candidates.set(fallbackWidth, fallbackUrl);
+
+    if (candidates.size <= 1) return undefined;
+    return [...candidates.entries()]
+        .sort(([left], [right]) => left - right)
+        .map(([width, url]) => `${url} ${width}w`)
+        .join(', ');
+};


### PR DESCRIPTION
This pass targets the remaining image-delivery/LCP bottleneck rather than further changing the prerender architecture.

Changes:
- batch-fetch Reddit post metadata during production data generation and extract signed responsive preview variants
- keep original `i.redd.it` URLs as fallbacks
- emit responsive `srcset`/`sizes` for post artwork, gallery tiles, Post of the Day, and related-post thumbnails
- retain generated intrinsic dimensions for layout reservation
- remove the post-page dominant-color reload path, which would otherwise fetch the full original image after a responsive candidate loaded and negate the byte savings
- keep normal dev/typecheck/unit-test data generation network-free
- add unit coverage for responsive srcset generation

If Reddit metadata lookup fails for any batch, the build falls back to the original URLs instead of failing deployment.