### PR TITLE
perf: enable SPA-style archive navigation

### DIFF
--- a/src/components/home/FeaturedVideo.astro
+++ b/src/components/home/FeaturedVideo.astro
@@ -9,19 +9,27 @@
 </section>
 
 <script>
-    const root = document.querySelector<HTMLElement>('[data-featured-video]');
-    const poster = root?.querySelector<HTMLButtonElement>('[data-video-poster]');
-    const frame = root?.querySelector<HTMLElement>('.video-frame');
+    const initializeFeaturedVideo = (): void => {
+        const root = document.querySelector<HTMLElement>('[data-featured-video]');
+        if (!root || root.dataset.initialized === 'true') return;
+        root.dataset.initialized = 'true';
 
-    poster?.addEventListener('click', () => {
-        if (!frame) return;
-        const iframe = document.createElement('iframe');
-        iframe.src = 'https://www.youtube-nocookie.com/embed/Gfev_ZEBRNk?autoplay=1';
-        iframe.title = 'Featured Video';
-        iframe.allow = 'autoplay; encrypted-media; picture-in-picture; web-share';
-        iframe.allowFullscreen = true;
-        frame.replaceChildren(iframe);
-    }, { once: true });
+        const poster = root.querySelector<HTMLButtonElement>('[data-video-poster]');
+        const frame = root.querySelector<HTMLElement>('.video-frame');
+
+        poster?.addEventListener('click', () => {
+            if (!frame) return;
+            const iframe = document.createElement('iframe');
+            iframe.src = 'https://www.youtube-nocookie.com/embed/Gfev_ZEBRNk?autoplay=1';
+            iframe.title = 'Featured Video';
+            iframe.allow = 'autoplay; encrypted-media; picture-in-picture; web-share';
+            iframe.allowFullscreen = true;
+            frame.replaceChildren(iframe);
+        }, { once: true });
+    };
+
+    document.addEventListener('astro:page-load', initializeFeaturedVideo);
+    initializeFeaturedVideo();
 </script>
 
 <style is:global>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,4 +1,5 @@
 ---
+import { ClientRouter } from 'astro:transitions';
 import '../styles/global.css';
 import { assetPath, pagePath } from '../utils/paths';
 import { DEFAULT_DESCRIPTION, SITE_NAME } from '../utils/siteMetadata';
@@ -74,8 +75,9 @@ const websiteSchema = {
         {ogImage && <meta property="og:image" content={ogImage} />}
         <meta name="twitter:card" content="summary_large_image" />
         <script is:inline type="application/ld+json" set:html={JSON.stringify(websiteSchema)}></script>
+        <ClientRouter fallback="swap" />
     </head>
-    <body>
+    <body transition:animate="none">
         <div class="layout">
             <header class="app-bar">
                 <nav class="toolbar" aria-label="Primary navigation">
@@ -154,14 +156,17 @@ const websiteSchema = {
         </div>
 
         <script>
+            import { navigate } from 'astro:transitions/client';
             import { assetPath, pagePath } from '../utils/paths';
 
-            const randomPostButtons = [...document.querySelectorAll<HTMLButtonElement>('[data-random-post]')];
             let postIdRequest: Promise<string[]> | undefined;
             let randomPostLoading = false;
 
+            const currentRandomPostButtons = (): HTMLButtonElement[] =>
+                [...document.querySelectorAll<HTMLButtonElement>('[data-random-post]')];
+
             const setRandomPostState = (label: string, busy: boolean): void => {
-                for (const button of randomPostButtons) {
+                for (const button of currentRandomPostButtons()) {
                     button.textContent = label;
                     button.disabled = busy;
                     button.setAttribute('aria-busy', String(busy));
@@ -195,7 +200,7 @@ const websiteSchema = {
                     const postIds = await fetchRandomPostIds();
                     if (postIds.length === 0) throw new Error('No posts are available.');
                     const id = postIds[Math.floor(Math.random() * postIds.length)];
-                    window.location.assign(pagePath(`posts/${id}`));
+                    navigate(pagePath(`posts/${id}`));
                 } catch (error) {
                     console.error('Unable to open a random post.', error);
                     randomPostLoading = false;
@@ -203,16 +208,21 @@ const websiteSchema = {
                 }
             };
 
-            for (const button of randomPostButtons) {
-                button.addEventListener('click', () => void goToRandomPost());
-            }
+            document.addEventListener('click', event => {
+                const button = (event.target as Element | null)?.closest<HTMLButtonElement>('[data-random-post]');
+                if (button) void goToRandomPost();
+            });
+
+            document.addEventListener('astro:page-load', () => {
+                randomPostLoading = false;
+            });
 
             if (import.meta.env.PROD && 'serviceWorker' in navigator) {
                 window.addEventListener('load', () => {
                     void navigator.serviceWorker.register(assetPath('service-worker.js'), {
                         scope: pagePath()
                     });
-                });
+                }, { once: true });
             }
         </script>
     </body>

--- a/src/pages/posts/[id].astro
+++ b/src/pages/posts/[id].astro
@@ -36,7 +36,7 @@ const socialImage = !data.post.nsfw
     ogImage={socialImage}
     currentSection="post"
 >
-    <section class="post-page">
+    <section class="post-page" data-post-page>
         <div class="images">
             {data.post.url.map((url, index) => {
                 const dimensions = data.post.imageDimensions?.[index];
@@ -72,8 +72,8 @@ const socialImage = !data.post.nsfw
                 <div class="links">
                     <a href={data.post.reddit} target="_blank" rel="noopener noreferrer">Reddit</a>
                     <a href={data.post.src} target="_blank" rel="noopener noreferrer">Source</a>
-                    {data.prevPostId && <a href={pagePath(`posts/${data.prevPostId}`)}>Previous</a>}
-                    {data.nextPostId && <a href={pagePath(`posts/${data.nextPostId}`)}>Next</a>}
+                    {data.prevPostId && <a href={pagePath(`posts/${data.prevPostId}`)} data-astro-prefetch="viewport">Previous</a>}
+                    {data.nextPostId && <a href={pagePath(`posts/${data.nextPostId}`)} data-astro-prefetch="viewport">Next</a>}
                 </div>
                 {data.post.nsfw && (
                     <button class="uncensor-button" type="button" aria-pressed="false" data-nsfw-toggle>
@@ -113,10 +113,7 @@ const socialImage = !data.post.nsfw
                     <div class="more-grid" data-more-grid></div>
                     <template data-more-template>
                         {data.relatedPosts.map(item => (
-                            <a
-                                href={pagePath(`posts/${item.id}`)}
-                                aria-label={`View another translated work by ${artistName}`}
-                            >
+                            <a href={pagePath(`posts/${item.id}`)} aria-label={`View another translated work by ${artistName}`}>
                                 <img
                                     class:list={{ nsfw: item.nsfw }}
                                     src={item.img}
@@ -137,55 +134,85 @@ const socialImage = !data.post.nsfw
     </section>
 
     <script>
-        const toggle = document.querySelector<HTMLButtonElement>('[data-nsfw-toggle]');
-        const morePanel = document.querySelector<HTMLDetailsElement>('[data-more-panel]');
-        const moreGrid = morePanel?.querySelector<HTMLElement>('[data-more-grid]');
-        const moreTemplate = morePanel?.querySelector<HTMLTemplateElement>('[data-more-template]');
-        const moreAction = morePanel?.querySelector<HTMLElement>('[data-more-action]');
-        const moreSummary = morePanel?.querySelector<HTMLElement>('summary');
-        const mobileLayout = window.matchMedia('(max-width: 900px)');
-        let revealed = false;
-        let moreImagesLoaded = false;
+        let cleanupPostPage: (() => void) | undefined;
 
-        const loadMoreImages = (): void => {
-            if (moreImagesLoaded || !moreGrid || !moreTemplate) return;
-            moreGrid.append(moreTemplate.content.cloneNode(true));
-            moreImagesLoaded = true;
+        const initializePostPage = (): void => {
+            const root = document.querySelector<HTMLElement>('[data-post-page]');
+            if (!root) {
+                cleanupPostPage?.();
+                cleanupPostPage = undefined;
+                return;
+            }
+            if (root.dataset.initialized === 'true') return;
 
-            if (revealed) {
-                for (const image of moreGrid.querySelectorAll<HTMLElement>('[data-nsfw-image]')) {
-                    image.classList.remove('nsfw');
+            cleanupPostPage?.();
+            root.dataset.initialized = 'true';
+
+            const toggle = root.querySelector<HTMLButtonElement>('[data-nsfw-toggle]');
+            const morePanel = root.querySelector<HTMLDetailsElement>('[data-more-panel]');
+            const moreGrid = morePanel?.querySelector<HTMLElement>('[data-more-grid]');
+            const moreTemplate = morePanel?.querySelector<HTMLTemplateElement>('[data-more-template]');
+            const moreAction = morePanel?.querySelector<HTMLElement>('[data-more-action]');
+            const moreSummary = morePanel?.querySelector<HTMLElement>('summary');
+            const mobileLayout = window.matchMedia('(max-width: 900px)');
+            let revealed = false;
+            let moreImagesLoaded = false;
+
+            const loadMoreImages = (): void => {
+                if (moreImagesLoaded || !moreGrid || !moreTemplate) return;
+                moreGrid.append(moreTemplate.content.cloneNode(true));
+                moreImagesLoaded = true;
+
+                if (revealed) {
+                    for (const image of moreGrid.querySelectorAll<HTMLElement>('[data-nsfw-image]')) {
+                        image.classList.remove('nsfw');
+                    }
                 }
-            }
-        };
+            };
 
-        const updateMorePanel = (): void => {
-            if (!morePanel) return;
-            if (!mobileLayout.matches) {
-                morePanel.open = true;
-                loadMoreImages();
-            }
-            if (moreAction) moreAction.textContent = morePanel.open ? 'Hide' : 'Show';
-        };
+            const updateMorePanel = (): void => {
+                if (!morePanel) return;
+                if (!mobileLayout.matches) {
+                    morePanel.open = true;
+                    loadMoreImages();
+                }
+                if (moreAction) moreAction.textContent = morePanel.open ? 'Hide' : 'Show';
+            };
 
-        morePanel?.addEventListener('toggle', () => {
-            if (morePanel.open) loadMoreImages();
+            const onToggle = (): void => {
+                if (morePanel?.open) loadMoreImages();
+                updateMorePanel();
+            };
+            const onSummaryClick = (event: MouseEvent): void => {
+                if (!mobileLayout.matches) event.preventDefault();
+            };
+            const onToggleNsfw = (): void => {
+                revealed = !revealed;
+                for (const image of root.querySelectorAll<HTMLElement>('[data-nsfw-image]')) {
+                    image.classList.toggle('nsfw', !revealed);
+                }
+                if (toggle) {
+                    toggle.setAttribute('aria-pressed', String(revealed));
+                    toggle.textContent = revealed ? 'Censor images' : 'Uncensor images';
+                }
+            };
+
+            morePanel?.addEventListener('toggle', onToggle);
+            moreSummary?.addEventListener('click', onSummaryClick);
+            mobileLayout.addEventListener('change', updateMorePanel);
+            toggle?.addEventListener('click', onToggleNsfw);
             updateMorePanel();
-        });
-        moreSummary?.addEventListener('click', event => {
-            if (!mobileLayout.matches) event.preventDefault();
-        });
-        mobileLayout.addEventListener('change', updateMorePanel);
-        updateMorePanel();
 
-        toggle?.addEventListener('click', () => {
-            revealed = !revealed;
-            for (const image of document.querySelectorAll<HTMLElement>('[data-nsfw-image]')) {
-                image.classList.toggle('nsfw', !revealed);
-            }
-            toggle.setAttribute('aria-pressed', String(revealed));
-            toggle.textContent = revealed ? 'Censor images' : 'Uncensor images';
-        });
+            cleanupPostPage = () => {
+                morePanel?.removeEventListener('toggle', onToggle);
+                moreSummary?.removeEventListener('click', onSummaryClick);
+                mobileLayout.removeEventListener('change', updateMorePanel);
+                toggle?.removeEventListener('click', onToggleNsfw);
+            };
+        };
+
+        document.addEventListener('astro:page-load', initializePostPage);
+        initializePostPage();
     </script>
 </BaseLayout>
 
@@ -198,212 +225,42 @@ const socialImage = !data.post.nsfw
         margin: 0 auto;
     }
 
-    .images {
-        display: grid;
-        gap: 1rem;
-    }
-
-    figure {
-        overflow: hidden;
-        padding: 0;
-        margin: 0;
-        background: var(--color-surface);
-        border: 1px solid var(--color-border);
-        border-radius: var(--radius-lg);
-        box-shadow: var(--shadow-sm);
-    }
-
-    figure img {
-        display: block;
-        width: auto;
-        max-width: 100%;
-        height: auto;
-        margin-inline: auto;
-    }
-
-    figure img.nsfw {
-        filter: blur(10px);
-    }
-
-    .info {
-        position: sticky;
-        top: 88px;
-        display: grid;
-        align-self: start;
-        gap: 1rem;
-    }
-
-    .panel {
-        padding: 1rem;
-        text-align: left;
-        background: var(--color-surface);
-        border: 1px solid var(--color-border);
-        border-radius: var(--radius-lg);
-        box-shadow: var(--shadow-sm);
-    }
-
-    .eyebrow {
-        margin: 0 0 0.35rem;
-        color: var(--color-muted);
-        font-size: 0.78rem;
-        font-weight: 800;
-        text-transform: uppercase;
-    }
-
-    h1 {
-        margin: 0;
-        color: var(--color-ink);
-        font-size: 1.35rem;
-    }
-
-    .artist-pill {
-        display: inline-flex;
-        max-width: 100%;
-        align-items: center;
-        padding: 0.45rem 0.8rem;
-        color: var(--color-primary);
-        line-height: 1.2;
-        text-decoration: none;
-        overflow-wrap: anywhere;
-        background: var(--color-primary-soft);
-        border: 1px solid color-mix(in srgb, var(--color-primary) 24%, transparent);
-        border-radius: 999px;
-    }
-
-    .artist-pill:hover {
-        color: var(--color-surface);
-        background: var(--color-primary);
-    }
-
-    .links,
-    .chips {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.5rem;
-        margin-top: 0.85rem;
-    }
-
-    .links a,
-    .chips a {
-        padding: 0.4rem 0.65rem;
-        color: var(--color-primary);
-        font-size: 0.86rem;
-        font-weight: 800;
-        text-decoration: none;
-        background: var(--color-primary-soft);
-        border-radius: 999px;
-    }
-
-    .chips a {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.45rem;
-    }
-
-    .character-avatar {
-        width: 26px;
-        height: 26px;
-        object-fit: cover;
-        border-radius: var(--radius-sm);
-    }
-
-    .uncensor-button {
-        width: 100%;
-        padding: 0.65rem 0.8rem;
-        margin-top: 0.85rem;
-        color: var(--color-surface);
-        font: inherit;
-        font-size: 0.9rem;
-        font-weight: 800;
-        cursor: pointer;
-        background: var(--color-primary);
-        border: 0;
-        border-radius: 999px;
-    }
-
-    .uncensor-button:hover {
-        background: var(--color-primary-hover);
-    }
-
-    .more-grid {
-        display: grid;
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-        gap: 0.55rem;
-    }
-
-    .more-panel summary {
-        list-style: none;
-    }
-
-    .more-panel summary::-webkit-details-marker {
-        display: none;
-    }
-
-    .more-panel summary .eyebrow {
-        margin-bottom: 0.35rem;
-    }
-
-    .more-action {
-        display: none;
-    }
-
-    .more-grid a {
-        overflow: hidden;
-        aspect-ratio: 1;
-        border-radius: var(--radius-md);
-    }
-
-    .more-grid img {
-        display: block;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-    }
-
-    .more-grid img.nsfw {
-        filter: blur(10px);
-    }
+    .images { display: grid; gap: 1rem; }
+    figure { overflow: hidden; padding: 0; margin: 0; background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--radius-lg); box-shadow: var(--shadow-sm); }
+    figure img { display: block; width: auto; max-width: 100%; height: auto; margin-inline: auto; }
+    figure img.nsfw { filter: blur(10px); }
+    .info { position: sticky; top: 88px; display: grid; align-self: start; gap: 1rem; }
+    .panel { padding: 1rem; text-align: left; background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--radius-lg); box-shadow: var(--shadow-sm); }
+    .eyebrow { margin: 0 0 0.35rem; color: var(--color-muted); font-size: 0.78rem; font-weight: 800; text-transform: uppercase; }
+    h1 { margin: 0; color: var(--color-ink); font-size: 1.35rem; }
+    .artist-pill { display: inline-flex; max-width: 100%; align-items: center; padding: 0.45rem 0.8rem; color: var(--color-primary); line-height: 1.2; text-decoration: none; overflow-wrap: anywhere; background: var(--color-primary-soft); border: 1px solid color-mix(in srgb, var(--color-primary) 24%, transparent); border-radius: 999px; }
+    .artist-pill:hover { color: var(--color-surface); background: var(--color-primary); }
+    .links, .chips { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-top: 0.85rem; }
+    .links a, .chips a { padding: 0.4rem 0.65rem; color: var(--color-primary); font-size: 0.86rem; font-weight: 800; text-decoration: none; background: var(--color-primary-soft); border-radius: 999px; }
+    .chips a { display: inline-flex; align-items: center; gap: 0.45rem; }
+    .character-avatar { width: 26px; height: 26px; object-fit: cover; border-radius: var(--radius-sm); }
+    .uncensor-button { width: 100%; padding: 0.65rem 0.8rem; margin-top: 0.85rem; color: var(--color-surface); font: inherit; font-size: 0.9rem; font-weight: 800; cursor: pointer; background: var(--color-primary); border: 0; border-radius: 999px; }
+    .uncensor-button:hover { background: var(--color-primary-hover); }
+    .more-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.55rem; }
+    .more-panel summary { list-style: none; }
+    .more-panel summary::-webkit-details-marker { display: none; }
+    .more-panel summary .eyebrow { margin-bottom: 0.35rem; }
+    .more-action { display: none; }
+    .more-grid a { overflow: hidden; aspect-ratio: 1; border-radius: var(--radius-md); }
+    .more-grid img { display: block; width: 100%; height: 100%; object-fit: cover; }
+    .more-grid img.nsfw { filter: blur(10px); }
 
     @media (max-width: 900px) {
-        .post-page {
-            grid-template-columns: 1fr;
-            padding: 1rem;
-        }
-
-        .info {
-            position: static;
-        }
-
-        .more-panel summary {
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            cursor: pointer;
-        }
-
-        .more-panel summary .eyebrow {
-            margin: 0;
-        }
-
-        .more-action {
-            display: inline;
-            color: var(--color-primary);
-            font-size: 0.86rem;
-            font-weight: 800;
-        }
-
-        .more-panel[open] summary {
-            margin-bottom: 0.55rem;
-        }
+        .post-page { grid-template-columns: 1fr; padding: 1rem; }
+        .info { position: static; }
+        .more-panel summary { display: flex; align-items: center; justify-content: space-between; cursor: pointer; }
+        .more-panel summary .eyebrow { margin: 0; }
+        .more-action { display: inline; color: var(--color-primary); font-size: 0.86rem; font-weight: 800; }
+        .more-panel[open] summary { margin-bottom: 0.55rem; }
     }
 </style>
 
 <style is:global>
-    .post-page .prose p:first-child {
-        margin-top: 0;
-    }
-
-    .post-page .prose p:last-child {
-        margin-bottom: 0;
-    }
+    .post-page .prose p:first-child { margin-top: 0; }
+    .post-page .prose p:last-child { margin-bottom: 0; }
 </style>

--- a/src/scripts/dailyPost.ts
+++ b/src/scripts/dailyPost.ts
@@ -3,10 +3,6 @@ import { assetPath, pagePath } from '../utils/paths';
 import { responsiveSrcset } from '../utils/responsiveImage';
 
 const millisecondsPerDay = 86_400_000;
-const root = document.querySelector<HTMLElement>('[data-daily-post]');
-const link = root?.querySelector<HTMLAnchorElement>('[data-daily-link]');
-const image = root?.querySelector<HTMLImageElement>('[data-daily-image]');
-const postCount = Number(root?.dataset.dailyCount ?? 0);
 
 const isHomePost = (value: unknown): value is HomePost => {
     if (!value || typeof value !== 'object') return false;
@@ -17,7 +13,16 @@ const isHomePost = (value: unknown): value is HomePost => {
         && typeof post.date === 'number';
 };
 
-if (postCount > 0 && link && image) {
+const initializeDailyPost = (): void => {
+    const root = document.querySelector<HTMLElement>('[data-daily-post]');
+    if (!root || root.dataset.initialized === 'true') return;
+    root.dataset.initialized = 'true';
+
+    const link = root.querySelector<HTMLAnchorElement>('[data-daily-link]');
+    const image = root.querySelector<HTMLImageElement>('[data-daily-image]');
+    const postCount = Number(root.dataset.dailyCount ?? 0);
+    if (postCount <= 0 || !link || !image) return;
+
     const day = Math.floor(Date.now() / millisecondsPerDay);
     const index = ((day % postCount) + postCount) % postCount;
 
@@ -40,4 +45,7 @@ if (postCount > 0 && link && image) {
             // Keep the server-rendered build-time daily post as a resilient fallback.
             console.error('Unable to refresh the post of the day.', error);
         });
-}
+};
+
+document.addEventListener('astro:page-load', initializeDailyPost);
+initializeDailyPost();

--- a/src/scripts/gallery.ts
+++ b/src/scripts/gallery.ts
@@ -184,6 +184,25 @@ const initializeGallery = (): void => {
     galleryOnlyButton?.addEventListener('click', () => { galleryOnly = !galleryOnly; currentPage = 1; void render().catch(reportLoadError); });
     dateSortButton?.addEventListener('click', () => { dateSort = dateSort === 'desc' ? 'asc' : 'desc'; currentPage = 1; void render().catch(reportLoadError); });
 
+    pagination?.addEventListener('click', event => {
+        const button = (event.target as Element | null)?.closest<HTMLButtonElement>('button');
+        if (!button || button.disabled || postsRequest) return;
+
+        const label = button.textContent?.trim() ?? '';
+        void loadPosts().then(() => {
+            if (label === 'Next') currentPage += 1;
+            else if (label === 'Previous') currentPage = Math.max(1, currentPage - 1);
+            else if (/^\d+$/.test(label)) currentPage = Number(label);
+            else if (label === '...') {
+                openJump = 'ellipsis-start';
+                jumpPage = String(currentPage);
+            }
+            return render();
+        }).then(() => {
+            if (label === '...') pagination.querySelector<HTMLInputElement>('.jump-form input')?.focus();
+        }).catch(reportLoadError);
+    });
+
     if (characterQueries.length > 0 || artistQueries.length > 0 || search.has('mode')) void render().catch(reportLoadError);
 };
 

--- a/src/scripts/gallery.ts
+++ b/src/scripts/gallery.ts
@@ -5,9 +5,28 @@ import { responsiveSrcset } from '../utils/responsiveImage';
 type JumpItem = 'ellipsis-start' | 'ellipsis-end';
 type PaginationItem = number | JumpItem;
 
-const root = document.querySelector<HTMLElement>('[data-gallery-page]');
+let postsRequest: Promise<GalleryPost[]> | undefined;
 
-if (root) {
+const loadPosts = (): Promise<GalleryPost[]> => {
+    postsRequest ??= fetch(assetPath('runtime-data/gallery-posts.json'))
+        .then(async response => {
+            if (!response.ok) throw new Error(`Gallery data request failed with ${response.status}.`);
+            const value: unknown = await response.json();
+            if (!Array.isArray(value)) throw new TypeError('Gallery data response was invalid.');
+            return value as GalleryPost[];
+        })
+        .catch(error => {
+            postsRequest = undefined;
+            throw error;
+        });
+    return postsRequest;
+};
+
+const initializeGallery = (): void => {
+    const root = document.querySelector<HTMLElement>('[data-gallery-page]');
+    if (!root || root.dataset.initialized === 'true') return;
+    root.dataset.initialized = 'true';
+
     const postsPerPage = 12;
     const grid = root.querySelector<HTMLElement>('[data-gallery-grid]');
     const postCount = root.querySelector<HTMLElement>('[data-post-count]');
@@ -16,43 +35,23 @@ if (root) {
     const pagination = root.querySelector<HTMLElement>('[data-pagination]');
     const search = new URLSearchParams(window.location.search);
 
-    let postsRequest: Promise<GalleryPost[]> | undefined;
     let currentPage = 1;
     let dateSort: SortOrder = 'desc';
     let galleryOnly = false;
-    let characterQueries = (search.get('characters') || '').split(',').map(value => value.trim()).filter(Boolean);
-    let artistQueries = (search.get('artist') || search.get('artists') || '').split(',').map(value => value.trim()).filter(Boolean);
-    let mode: 'and' | 'or' = search.get('mode') === 'or' ? 'or' : 'and';
+    const characterQueries = (search.get('characters') || '').split(',').map(value => value.trim()).filter(Boolean);
+    const artistQueries = (search.get('artist') || search.get('artists') || '').split(',').map(value => value.trim()).filter(Boolean);
+    const mode: 'and' | 'or' = search.get('mode') === 'or' ? 'or' : 'and';
     let openJump: JumpItem | null = null;
     let jumpPage = '';
-
-    const loadPosts = (): Promise<GalleryPost[]> => {
-        postsRequest ??= fetch(assetPath('runtime-data/gallery-posts.json'))
-            .then(async response => {
-                if (!response.ok) throw new Error(`Gallery data request failed with ${response.status}.`);
-                const value: unknown = await response.json();
-                if (!Array.isArray(value)) throw new TypeError('Gallery data response was invalid.');
-                return value as GalleryPost[];
-            })
-            .catch(error => {
-                postsRequest = undefined;
-                throw error;
-            });
-        return postsRequest;
-    };
 
     const getPaginationItems = (page: number, pageCount: number): PaginationItem[] => {
         if (pageCount <= 7) return Array.from({ length: pageCount }, (_, index) => index + 1);
         const pages = new Set([1, pageCount, page - 1, page, page + 1]);
-        const validPages = [...pages]
-            .filter(pageNumber => pageNumber >= 1 && pageNumber <= pageCount)
-            .sort((left, right) => left - right);
+        const validPages = [...pages].filter(pageNumber => pageNumber >= 1 && pageNumber <= pageCount).sort((a, b) => a - b);
         const items: PaginationItem[] = [];
         validPages.forEach((pageNumber, index) => {
             const previous = validPages[index - 1];
-            if (previous && pageNumber - previous > 1) {
-                items.push(previous === 1 ? 'ellipsis-start' : 'ellipsis-end');
-            }
+            if (previous && pageNumber - previous > 1) items.push(previous === 1 ? 'ellipsis-start' : 'ellipsis-end');
             items.push(pageNumber);
         });
         return items;
@@ -89,32 +88,30 @@ if (root) {
         return link;
     };
 
+    const clampPage = (value: string, totalPages: number): number => {
+        const page = Number(value);
+        if (!Number.isInteger(page)) return currentPage;
+        return Math.min(totalPages, Math.max(1, page));
+    };
+
     const renderPagination = (totalPages: number): void => {
         if (!pagination) return;
         pagination.hidden = totalPages <= 1;
         if (totalPages <= 1) return;
 
         const children: HTMLElement[] = [];
-        const previous = createButton('Previous', () => {
-            currentPage -= 1;
-            void render();
-        });
+        const previous = createButton('Previous', () => { currentPage -= 1; void render(); });
         previous.disabled = currentPage === 1;
         children.push(previous);
 
         for (const item of getPaginationItems(currentPage, totalPages)) {
             if (typeof item === 'number') {
-                const button = createButton(String(item), () => {
-                    currentPage = item;
-                    openJump = null;
-                    void render();
-                });
+                const button = createButton(String(item), () => { currentPage = item; openJump = null; void render(); });
                 button.classList.toggle('active', item === currentPage);
                 if (item === currentPage) button.setAttribute('aria-current', 'page');
                 children.push(button);
                 continue;
             }
-
             if (openJump === item) {
                 const form = document.createElement('form');
                 form.className = 'jump-form';
@@ -125,16 +122,8 @@ if (root) {
                 input.value = jumpPage;
                 input.setAttribute('aria-label', `Jump to page between 1 and ${totalPages}`);
                 input.addEventListener('input', () => jumpPage = input.value);
-                input.addEventListener('blur', () => {
-                    jumpPage = String(clampPage(jumpPage, totalPages));
-                    input.value = jumpPage;
-                });
-                input.addEventListener('keydown', event => {
-                    if (event.key === 'Escape') {
-                        openJump = null;
-                        void render();
-                    }
-                });
+                input.addEventListener('blur', () => { jumpPage = String(clampPage(jumpPage, totalPages)); input.value = jumpPage; });
+                input.addEventListener('keydown', event => { if (event.key === 'Escape') { openJump = null; void render(); } });
                 const submit = document.createElement('button');
                 submit.type = 'submit';
                 submit.textContent = 'Go';
@@ -159,41 +148,26 @@ if (root) {
             }
         }
 
-        const next = createButton('Next', () => {
-            currentPage += 1;
-            void render();
-        });
+        const next = createButton('Next', () => { currentPage += 1; void render(); });
         next.disabled = currentPage === totalPages;
         children.push(next);
         pagination.replaceChildren(...children);
-    };
-
-    const clampPage = (value: string, totalPages: number): number => {
-        const page = Number(value);
-        if (!Number.isInteger(page)) return currentPage;
-        return Math.min(totalPages, Math.max(1, page));
     };
 
     const render = async (): Promise<void> => {
         const posts = await loadPosts();
         const filteredPosts = posts.filter(post => {
             if (galleryOnly && post.nsfw) return false;
-            const characterMatch = characterQueries.length === 0
-                || (mode === 'and'
-                    ? characterQueries.every(id => post.characterIds.includes(id))
-                    : characterQueries.some(id => post.characterIds.includes(id)));
+            const characterMatch = characterQueries.length === 0 || (mode === 'and'
+                ? characterQueries.every(id => post.characterIds.includes(id))
+                : characterQueries.some(id => post.characterIds.includes(id)));
             const artistMatch = artistQueries.length === 0 || artistQueries.includes(post.artistId);
             return characterMatch && artistMatch;
         });
-        const sortedPosts = [...filteredPosts].sort((left, right) => (
-            dateSort === 'asc' ? left.date - right.date : right.date - left.date
-        ));
+        const sortedPosts = [...filteredPosts].sort((left, right) => dateSort === 'asc' ? left.date - right.date : right.date - left.date);
         const totalPages = Math.max(1, Math.ceil(sortedPosts.length / postsPerPage));
         if (currentPage > totalPages) currentPage = totalPages;
-        const visiblePosts = sortedPosts.slice(
-            (currentPage - 1) * postsPerPage,
-            currentPage * postsPerPage
-        );
+        const visiblePosts = sortedPosts.slice((currentPage - 1) * postsPerPage, currentPage * postsPerPage);
 
         grid?.replaceChildren(...visiblePosts.map(makeTile));
         if (postCount) postCount.textContent = `${filteredPosts.length} post${filteredPosts.length === 1 ? '' : 's'}`;
@@ -205,41 +179,13 @@ if (root) {
         renderPagination(totalPages);
     };
 
-    const reportLoadError = (error: unknown): void => {
-        console.error('Unable to load gallery data.', error);
-    };
+    const reportLoadError = (error: unknown): void => console.error('Unable to load gallery data.', error);
 
-    galleryOnlyButton?.addEventListener('click', () => {
-        galleryOnly = !galleryOnly;
-        currentPage = 1;
-        void render().catch(reportLoadError);
-    });
-    dateSortButton?.addEventListener('click', () => {
-        dateSort = dateSort === 'desc' ? 'asc' : 'desc';
-        currentPage = 1;
-        void render().catch(reportLoadError);
-    });
+    galleryOnlyButton?.addEventListener('click', () => { galleryOnly = !galleryOnly; currentPage = 1; void render().catch(reportLoadError); });
+    dateSortButton?.addEventListener('click', () => { dateSort = dateSort === 'desc' ? 'asc' : 'desc'; currentPage = 1; void render().catch(reportLoadError); });
 
-    pagination?.addEventListener('click', event => {
-        const button = (event.target as Element | null)?.closest<HTMLButtonElement>('button');
-        if (!button || button.disabled || postsRequest) return;
+    if (characterQueries.length > 0 || artistQueries.length > 0 || search.has('mode')) void render().catch(reportLoadError);
+};
 
-        const label = button.textContent?.trim() ?? '';
-        void loadPosts().then(() => {
-            if (label === 'Next') currentPage += 1;
-            else if (label === 'Previous') currentPage = Math.max(1, currentPage - 1);
-            else if (/^\d+$/.test(label)) currentPage = Number(label);
-            else if (label === '...') {
-                openJump = 'ellipsis-start';
-                jumpPage = String(currentPage);
-            }
-            return render();
-        }).then(() => {
-            if (label === '...') pagination.querySelector<HTMLInputElement>('.jump-form input')?.focus();
-        }).catch(reportLoadError);
-    });
-
-    if (characterQueries.length > 0 || artistQueries.length > 0 || search.has('mode')) {
-        void render().catch(reportLoadError);
-    }
-}
+document.addEventListener('astro:page-load', initializeGallery);
+initializeGallery();

--- a/src/scripts/listPage.ts
+++ b/src/scripts/listPage.ts
@@ -4,10 +4,12 @@ import { assetPath, pagePathWithQuery } from '../utils/paths';
 type ListItem = Artist | Character;
 type ListMode = 'character' | 'artist';
 
-const root = document.querySelector<HTMLElement>('[data-list-page]');
-const dataElement = root?.querySelector<HTMLScriptElement>('[data-list-data]');
+const initializeListPage = (): void => {
+    const root = document.querySelector<HTMLElement>('[data-list-page]');
+    const dataElement = root?.querySelector<HTMLScriptElement>('[data-list-data]');
+    if (!root || !dataElement || root.dataset.initialized === 'true') return;
+    root.dataset.initialized = 'true';
 
-if (root && dataElement) {
     const mode = root.dataset.mode as ListMode;
     const items = JSON.parse(dataElement.textContent ?? '[]') as ListItem[];
     const searchInput = root.querySelector<HTMLInputElement>('[data-list-search]');
@@ -31,15 +33,9 @@ if (root && dataElement) {
             : right.artworkCount - left.artworkCount;
         if (primaryDifference !== 0) return primaryDifference;
 
-        const leftSecondary = mode === 'character'
-            ? (left as Character).artistCount
-            : (left as Artist).characterCount;
-        const rightSecondary = mode === 'character'
-            ? (right as Character).artistCount
-            : (right as Artist).characterCount;
-        return sortOrder === 'asc'
-            ? leftSecondary - rightSecondary
-            : rightSecondary - leftSecondary;
+        const leftSecondary = mode === 'character' ? (left as Character).artistCount : (left as Artist).characterCount;
+        const rightSecondary = mode === 'character' ? (right as Character).artistCount : (right as Artist).characterCount;
+        return sortOrder === 'asc' ? leftSecondary - rightSecondary : rightSecondary - leftSecondary;
     };
 
     const selectedGalleryUrl = (id: string): string => {
@@ -68,9 +64,7 @@ if (root && dataElement) {
             box.type = 'button';
             box.setAttribute('aria-pressed', String(selected));
             box.addEventListener('click', () => {
-                selectedItems = selected
-                    ? selectedItems.filter(id => id !== item.id)
-                    : [...selectedItems, item.id];
+                selectedItems = selected ? selectedItems.filter(id => id !== item.id) : [...selectedItems, item.id];
                 render();
             });
         } else {
@@ -102,9 +96,7 @@ if (root && dataElement) {
         }
         text.append(makeText('name large-name', item.name));
         text.append(makeText('desc', `${item.artworkCount} artwork${item.artworkCount === 1 ? '' : 's'}`));
-        const secondaryCount = mode === 'character'
-            ? (item as Character).artistCount
-            : (item as Artist).characterCount;
+        const secondaryCount = mode === 'character' ? (item as Character).artistCount : (item as Artist).characterCount;
         const secondaryLabel = mode === 'character' ? 'artist' : 'character';
         text.append(makeText('desc', `${secondaryCount} ${secondaryLabel}${secondaryCount === 1 ? '' : 's'}`));
 
@@ -118,8 +110,7 @@ if (root && dataElement) {
         if (!grid || !sortButton || !loadMoreButton) return;
         const query = searchValue.toLocaleLowerCase();
         const searchedItems = query
-            ? items.filter(item => [item.id, item.name]
-                .some(value => value.toLocaleLowerCase().includes(query)))
+            ? items.filter(item => [item.id, item.name].some(value => value.toLocaleLowerCase().includes(query)))
             : items;
         const sortedItems = [...searchedItems].sort(compareItems);
         grid.replaceChildren(...sortedItems.slice(0, visibleCount).map(renderItem));
@@ -131,9 +122,7 @@ if (root && dataElement) {
         if (selectModeButton) {
             selectModeButton.classList.toggle('active', isSelectMode);
             selectModeButton.setAttribute('aria-pressed', String(isSelectMode));
-            selectModeButton.textContent = isSelectMode
-                ? `${selectedItems.length || 'Multi'} Selected`
-                : 'Multi-Select OFF';
+            selectModeButton.textContent = isSelectMode ? `${selectedItems.length || 'Multi'} Selected` : 'Multi-Select OFF';
         }
         if (viewSelectedLink) {
             viewSelectedLink.hidden = !isSelectMode || selectedItems.length === 0;
@@ -141,22 +130,13 @@ if (root && dataElement) {
         }
     };
 
-    searchInput?.addEventListener('input', () => {
-        searchValue = searchInput.value;
-        render();
-    });
-    sortButton?.addEventListener('click', () => {
-        sortOrder = sortOrder === 'none' ? 'desc' : sortOrder === 'desc' ? 'asc' : 'none';
-        render();
-    });
-    selectModeButton?.addEventListener('click', () => {
-        isSelectMode = !isSelectMode;
-        render();
-    });
-    loadMoreButton?.addEventListener('click', () => {
-        visibleCount += pageSize;
-        render();
-    });
+    searchInput?.addEventListener('input', () => { searchValue = searchInput.value; render(); });
+    sortButton?.addEventListener('click', () => { sortOrder = sortOrder === 'none' ? 'desc' : sortOrder === 'desc' ? 'asc' : 'none'; render(); });
+    selectModeButton?.addEventListener('click', () => { isSelectMode = !isSelectMode; render(); });
+    loadMoreButton?.addEventListener('click', () => { visibleCount += pageSize; render(); });
 
     render();
-}
+};
+
+document.addEventListener('astro:page-load', initializeListPage);
+initializeListPage();

--- a/tests/e2e/spa.spec.ts
+++ b/tests/e2e/spa.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test } from '@playwright/test';
+
+test('archive browsing stays in the Astro client router', async ({ page }) => {
+    await page.goto('gallery/', { waitUntil: 'domcontentloaded' });
+
+    await page.evaluate(() => {
+        (window as Window & { __spaNavigationMarker?: string }).__spaNavigationMarker = 'alive';
+    });
+
+    await page.locator('[data-gallery-grid] a.tile').first().click();
+    await expect(page).toHaveURL(/\/touhou-translations\/posts\/[^/]+\/$/);
+    await expect(page.locator('.artist-pill')).toBeVisible();
+    expect(await page.evaluate(() =>
+        (window as Window & { __spaNavigationMarker?: string }).__spaNavigationMarker
+    )).toBe('alive');
+
+    const adjacent = page.locator('.links a').filter({ hasText: /^(Previous|Next)$/ }).first();
+    await expect(adjacent).toBeVisible();
+    const firstPostUrl = page.url();
+    await adjacent.click();
+    await expect(page).not.toHaveURL(firstPostUrl);
+    await expect(page.locator('.artist-pill')).toBeVisible();
+    expect(await page.evaluate(() =>
+        (window as Window & { __spaNavigationMarker?: string }).__spaNavigationMarker
+    )).toBe('alive');
+
+    await page.getByRole('link', { name: 'Gallery', exact: true }).first().click();
+    await expect(page).toHaveURL(/\/touhou-translations\/gallery\/$/);
+    expect(await page.evaluate(() =>
+        (window as Window & { __spaNavigationMarker?: string }).__spaNavigationMarker
+    )).toBe('alive');
+
+    const contentFilter = page.getByRole('button', { name: 'All Posts' });
+    await contentFilter.click();
+    await expect(page.getByRole('button', { name: 'SFW Only' })).toHaveAttribute('aria-pressed', 'true');
+});


### PR DESCRIPTION
Makes internal browsing SPA-like while preserving static prerendered HTML for direct entry and SEO.

- enables Astro ClientRouter site-wide with swap fallback and no transition animation delay
- routes the random Post button through Astro's programmatic client navigation
- prefetches Previous/Next post documents when their controls enter the viewport
- makes Post, Gallery, Artists/Characters, Daily Post, and Featured Video scripts reinitialize safely after client-side swaps
- preserves the existing service-worker runtime cache as a second layer beneath Astro routing
- adds Playwright coverage that verifies Gallery → Post → adjacent Post → Gallery keeps the same browser document alive and restores Gallery interactivity