### PR TITLE
perf: limit SPA routing to post browsing

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     cacheDir: './.astro',
     output: 'static',
     trailingSlash: 'always',
+    prefetch: false,
     build: {
         format: 'directory'
     },

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -26,6 +26,8 @@ const {
     noindex = false
 } = Astro.props;
 
+const enableClientRouter = currentSection === 'post';
+
 const links = [
     { label: 'Home', href: pagePath(), section: 'home' },
     { label: 'Characters', href: pagePath('characters'), section: 'characters' },
@@ -75,7 +77,7 @@ const websiteSchema = {
         {ogImage && <meta property="og:image" content={ogImage} />}
         <meta name="twitter:card" content="summary_large_image" />
         <script is:inline type="application/ld+json" set:html={JSON.stringify(websiteSchema)}></script>
-        <ClientRouter fallback="swap" />
+        {enableClientRouter && <ClientRouter fallback="swap" />}
     </head>
     <body transition:animate="none">
         <div class="layout">
@@ -156,7 +158,6 @@ const websiteSchema = {
         </div>
 
         <script>
-            import { navigate } from 'astro:transitions/client';
             import { assetPath, pagePath } from '../utils/paths';
 
             let postIdRequest: Promise<string[]> | undefined;
@@ -200,7 +201,7 @@ const websiteSchema = {
                     const postIds = await fetchRandomPostIds();
                     if (postIds.length === 0) throw new Error('No posts are available.');
                     const id = postIds[Math.floor(Math.random() * postIds.length)];
-                    navigate(pagePath(`posts/${id}`));
+                    window.location.assign(pagePath(`posts/${id}`));
                 } catch (error) {
                     console.error('Unable to open a random post.', error);
                     randomPostLoading = false;

--- a/tests/e2e/spa.spec.ts
+++ b/tests/e2e/spa.spec.ts
@@ -1,18 +1,17 @@
 import { expect, test } from '@playwright/test';
 
-test('archive browsing stays in the Astro client router', async ({ page }) => {
+test('adjacent post browsing stays in the Astro client router', async ({ page }) => {
     await page.goto('gallery/', { waitUntil: 'domcontentloaded' });
+
+    // Gallery intentionally stays a plain static page. Entering a post may replace
+    // the document; only sequential post-to-post browsing needs SPA semantics.
+    await page.locator('[data-gallery-grid] a.tile').first().click();
+    await expect(page).toHaveURL(/\/touhou-translations\/posts\/[^/]+\/$/);
+    await expect(page.locator('.artist-pill')).toBeVisible();
 
     await page.evaluate(() => {
         (window as Window & { __spaNavigationMarker?: string }).__spaNavigationMarker = 'alive';
     });
-
-    await page.locator('[data-gallery-grid] a.tile').first().click();
-    await expect(page).toHaveURL(/\/touhou-translations\/posts\/[^/]+\/$/);
-    await expect(page.locator('.artist-pill')).toBeVisible();
-    expect(await page.evaluate(() =>
-        (window as Window & { __spaNavigationMarker?: string }).__spaNavigationMarker
-    )).toBe('alive');
 
     const adjacent = page.locator('.links a').filter({ hasText: /^(Previous|Next)$/ }).first();
     await expect(adjacent).toBeVisible();
@@ -24,11 +23,12 @@ test('archive browsing stays in the Astro client router', async ({ page }) => {
         (window as Window & { __spaNavigationMarker?: string }).__spaNavigationMarker
     )).toBe('alive');
 
+    // Leaving the post section intentionally returns to ordinary document navigation.
     await page.getByRole('link', { name: 'Gallery', exact: true }).first().click();
     await expect(page).toHaveURL(/\/touhou-translations\/gallery\/$/);
     expect(await page.evaluate(() =>
         (window as Window & { __spaNavigationMarker?: string }).__spaNavigationMarker
-    )).toBe('alive');
+    )).toBeUndefined();
 
     const contentFilter = page.getByRole('button', { name: 'All Posts' });
     await contentFilter.click();


### PR DESCRIPTION
Reduces the cold-load cost introduced by the site-wide SPA rollout while preserving fast sequential post browsing.

- disables Astro's global prefetch feature so it does not duplicate service-worker adjacent-post warming
- renders ClientRouter only on post pages
- removes the shared astro:transitions/client import from non-post pages
- keeps post-to-post Previous/Next and related-post navigation inside Astro's client router
- restores ordinary static document navigation for Home, Gallery, Artists, and Characters
- updates Playwright coverage to assert SPA persistence only across adjacent post navigation

This targets PageSpeed/Lighthouse first-load performance while retaining the interaction improvement that motivated the SPA work.