### PR TITLE
perf: replace SPA routing with native fast navigation

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -10,7 +10,10 @@ export default defineConfig({
     cacheDir: './.astro',
     output: 'static',
     trailingSlash: 'always',
-    prefetch: false,
+    prefetch: {
+        prefetchAll: true,
+        defaultStrategy: 'hover'
+    },
     build: {
         format: 'directory'
     },

--- a/scripts/generateServiceWorker.ts
+++ b/scripts/generateServiceWorker.ts
@@ -54,8 +54,11 @@ const metadataAssetPaths = ['favicon.ico', 'robots.txt', 'manifest.webmanifest']
 const pwaIconPaths = collectFiles(path.join(publicDir, 'icons', 'pwa'))
     .filter(filePath => /\.png$/i.test(filePath))
     .map(filePath => toPortablePath(path.relative(publicDir, filePath)));
-const postDocumentPaths = collectFiles(path.join(buildDir, 'posts'))
-    .filter(filePath => path.basename(filePath) === 'index.html')
+const documentPaths = collectFiles(buildDir)
+    .filter(filePath => /\.html$/i.test(filePath))
+    .sort();
+const runtimeDataPaths = collectFiles(path.join(buildDir, 'runtime-data'))
+    .filter(filePath => /\.json$/i.test(filePath))
     .sort();
 
 const entriesByUrl = new Map<string, PrecacheEntry>();
@@ -74,9 +77,9 @@ for (const entry of precacheEntries) {
     contentHash.update('\0');
 }
 
-// Post pages are runtime-cached. Include their contents in the cache version so a
-// deployment that edits an existing post cannot leave an older cached document behind.
-for (const filePath of postDocumentPaths) {
+// Runtime-cached documents and JSON must rotate with a deployment even though they
+// are intentionally not all downloaded during service-worker installation.
+for (const filePath of [...documentPaths, ...runtimeDataPaths]) {
     contentHash.update(toPortablePath(path.relative(buildDir, filePath)));
     contentHash.update('\0');
     contentHash.update(fs.readFileSync(filePath));
@@ -88,7 +91,6 @@ const precacheUrls = precacheEntries.map(entry => entry.url);
 const workerSource = `'use strict';
 
 const BASE_PATH = ${JSON.stringify(basePath)};
-const POST_PATH_PREFIX = BASE_PATH + 'posts/';
 const CACHE_PREFIX = ${JSON.stringify(cachePrefix)};
 const CACHE_NAME = ${JSON.stringify(cacheName)};
 const PRECACHE_URLS = ${JSON.stringify(precacheUrls, null, 4)};
@@ -105,7 +107,7 @@ async function updateCache(request, response) {
         const cache = await caches.open(CACHE_NAME);
         await cache.put(request, cachedResponse);
     } catch {
-        // A cache write failure must not turn a successful network request into a failure.
+        // Cache writes are opportunistic and must never affect a successful request.
     }
 }
 
@@ -115,97 +117,27 @@ async function matchCachedNavigation(request) {
         ?? await cache.match(request, { ignoreSearch: true });
 }
 
-function networkFirst(event) {
-    const networkResult = fetch(event.request).then(response => ({
-        response,
-        cacheUpdate: updateCache(event.request, response)
-    }));
+function navigationCacheFirst(event) {
+    const networkResponse = (async () => {
+        const preloaded = await event.preloadResponse;
+        return preloaded ?? await fetch(event.request);
+    })();
 
     event.waitUntil(
-        networkResult
-            .then(result => result.cacheUpdate)
+        networkResponse
+            .then(response => updateCache(event.request, response))
             .catch(() => undefined)
     );
 
-    return networkResult
-        .then(result => result.response)
-        .catch(async () => await matchCachedNavigation(event.request) ?? Response.error());
-}
-
-async function cacheAdjacentPostDocuments(response) {
-    if (!canCache(response)) return;
-
-    let html;
-    try {
-        html = await response.clone().text();
-    } catch {
-        return;
-    }
-
-    const adjacentUrls = new Set();
-    const adjacentLinkPattern = /<a[^>]*href=(["'])([^"']+)["'][^>]*>[^<]*(?:Previous|Next)[^<]*<[/]a>/gi;
-    for (const match of html.matchAll(adjacentLinkPattern)) {
-        try {
-            const url = new URL(match[2], self.location.origin);
-            if (url.origin === self.location.origin && url.pathname.startsWith(POST_PATH_PREFIX)) {
-                adjacentUrls.add(url.href);
-            }
-        } catch {
-            // Ignore malformed links rather than affecting the current navigation.
-        }
-    }
-
-    if (adjacentUrls.size === 0) return;
-
-    const cache = await caches.open(CACHE_NAME);
-    await Promise.all([...adjacentUrls].map(async url => {
-        const request = new Request(url, { credentials: 'same-origin' });
-        if (await cache.match(request, { ignoreSearch: true })) return;
-
-        try {
-            const adjacentResponse = await fetch(request);
-            await updateCache(request, adjacentResponse);
-        } catch {
-            // Adjacent warming is opportunistic and must never affect the current page.
-        }
-    }));
-}
-
-function postNavigationCacheFirst(event) {
-    const result = caches.open(CACHE_NAME).then(async cache => {
-        const cachedResponse = await cache.match(event.request, { ignoreSearch: true });
-        if (cachedResponse) {
-            return {
-                response: cachedResponse,
-                backgroundUpdate: cacheAdjacentPostDocuments(cachedResponse)
-            };
-        }
-
-        const response = await fetch(event.request);
-        return {
-            response,
-            backgroundUpdate: Promise.all([
-                updateCache(event.request, response),
-                cacheAdjacentPostDocuments(response)
-            ]).then(() => undefined)
-        };
-    });
-
-    event.waitUntil(
-        result
-            .then(value => value.backgroundUpdate)
-            .catch(() => undefined)
-    );
-
-    return result.then(value => value.response);
+    return matchCachedNavigation(event.request)
+        .then(cachedResponse => cachedResponse ?? networkResponse)
+        .catch(() => networkResponse);
 }
 
 function cacheFirst(event) {
     const result = caches.open(CACHE_NAME).then(async cache => {
         const cachedResponse = await cache.match(event.request);
-        if (cachedResponse) {
-            return { response: cachedResponse, cacheUpdate: Promise.resolve() };
-        }
+        if (cachedResponse) return { response: cachedResponse, cacheUpdate: Promise.resolve() };
 
         const response = await fetch(event.request);
         return { response, cacheUpdate: updateCache(event.request, response) };
@@ -229,13 +161,17 @@ self.addEventListener('install', event => {
 });
 
 self.addEventListener('activate', event => {
-    event.waitUntil(
-        caches.keys()
-            .then(keys => Promise.all(keys
-                .filter(key => key.startsWith(CACHE_PREFIX) && key !== CACHE_NAME)
-                .map(key => caches.delete(key))))
-            .then(() => self.clients.claim())
-    );
+    event.waitUntil((async () => {
+        if (self.registration.navigationPreload) {
+            await self.registration.navigationPreload.enable();
+        }
+
+        const keys = await caches.keys();
+        await Promise.all(keys
+            .filter(key => key.startsWith(CACHE_PREFIX) && key !== CACHE_NAME)
+            .map(key => caches.delete(key)));
+        await self.clients.claim();
+    })());
 });
 
 self.addEventListener('fetch', event => {
@@ -246,11 +182,7 @@ self.addEventListener('fetch', event => {
     if (url.origin !== self.location.origin || !url.pathname.startsWith(BASE_PATH)) return;
 
     if (request.mode === 'navigate') {
-        event.respondWith(
-            url.pathname.startsWith(POST_PATH_PREFIX)
-                ? postNavigationCacheFirst(event)
-                : networkFirst(event)
-        );
+        event.respondWith(navigationCacheFirst(event));
         return;
     }
 

--- a/scripts/publishRuntimeData.ts
+++ b/scripts/publishRuntimeData.ts
@@ -18,6 +18,8 @@ fs.rmSync(runtimeDir, { recursive: true, force: true });
 fs.mkdirSync(dailyPostsDir, { recursive: true });
 
 copyGeneratedFile('gallery-posts.json', path.join(runtimeDir, 'gallery-posts.json'));
+copyGeneratedFile('artists.json', path.join(runtimeDir, 'artists.json'));
+copyGeneratedFile('characters.json', path.join(runtimeDir, 'characters.json'));
 copyGeneratedFile('post-ids.json', path.join(publicDir, 'post-ids.json'));
 
 const homePosts = JSON.parse(

--- a/src/components/list/ListPage.astro
+++ b/src/components/list/ListPage.astro
@@ -2,7 +2,6 @@
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import type { Artist, Character } from '../../types/data';
 import { absoluteSiteUrl } from '../../utils/siteMetadata';
-import { serializeForScript } from '../../utils/serializeForScript';
 import ProfileCard from './ProfileCard.astro';
 
 interface Props {
@@ -11,7 +10,7 @@ interface Props {
 }
 
 const { mode, items } = Astro.props;
-const pageSize = 50;
+const pageSize = 24;
 const title = mode === 'character' ? 'Character List' : 'Artist List';
 const description = mode === 'character'
     ? 'Browse Touhou Project characters featured in the translated archive.'
@@ -33,7 +32,7 @@ const initialItems = mode === 'artist'
     ogTitle={`${title} | Touhou Translations`}
     currentSection={mode === 'character' ? 'characters' : 'artists'}
 >
-    <section class="list-page" data-list-page data-mode={mode}>
+    <section class="list-page" data-list-page data-mode={mode} data-page-size={pageSize}>
         <div class="list-toolbar">
             <h1>{title}</h1>
             <label>
@@ -61,7 +60,6 @@ const initialItems = mode === 'artist'
         </ul>
 
         <button class="load-more" type="button" data-load-more hidden={initialItems.length <= pageSize}>Load More</button>
-        <script is:inline type="application/json" data-list-data set:html={serializeForScript(items)}></script>
     </section>
     <script src="../../scripts/listPage.ts"></script>
 </BaseLayout>
@@ -161,6 +159,8 @@ const initialItems = mode === 'artist'
     .list-page .profile-item {
         height: 100%;
         overflow: hidden;
+        content-visibility: auto;
+        contain-intrinsic-size: auto 150px;
         background: var(--color-surface);
         border: 1px solid var(--color-border);
         border-radius: var(--radius-lg);

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,5 +1,4 @@
 ---
-import { ClientRouter } from 'astro:transitions';
 import '../styles/global.css';
 import { assetPath, pagePath } from '../utils/paths';
 import { DEFAULT_DESCRIPTION, SITE_NAME } from '../utils/siteMetadata';
@@ -25,8 +24,6 @@ const {
     currentSection,
     noindex = false
 } = Astro.props;
-
-const enableClientRouter = currentSection === 'post';
 
 const links = [
     { label: 'Home', href: pagePath(), section: 'home' },
@@ -69,6 +66,7 @@ const websiteSchema = {
         <link rel="icon" href={assetPath('favicon.ico')} type="image/x-icon" />
         <link rel="apple-touch-icon" href={assetPath('icons/pwa/pwa-icon-192x192.png')} />
         <link rel="preconnect" href="https://i.redd.it" />
+        <link rel="preconnect" href="https://preview.redd.it" />
         <meta property="og:site_name" content={SITE_NAME} />
         <meta property="og:title" content={ogTitle} />
         <meta property="og:description" content={description} />
@@ -77,9 +75,8 @@ const websiteSchema = {
         {ogImage && <meta property="og:image" content={ogImage} />}
         <meta name="twitter:card" content="summary_large_image" />
         <script is:inline type="application/ld+json" set:html={JSON.stringify(websiteSchema)}></script>
-        {enableClientRouter && <ClientRouter fallback="swap" />}
     </head>
-    <body transition:animate="none">
+    <body>
         <div class="layout">
             <header class="app-bar">
                 <nav class="toolbar" aria-label="Primary navigation">
@@ -163,11 +160,10 @@ const websiteSchema = {
             let postIdRequest: Promise<string[]> | undefined;
             let randomPostLoading = false;
 
-            const currentRandomPostButtons = (): HTMLButtonElement[] =>
-                [...document.querySelectorAll<HTMLButtonElement>('[data-random-post]')];
+            const randomPostButtons = [...document.querySelectorAll<HTMLButtonElement>('[data-random-post]')];
 
             const setRandomPostState = (label: string, busy: boolean): void => {
-                for (const button of currentRandomPostButtons()) {
+                for (const button of randomPostButtons) {
                     button.textContent = label;
                     button.disabled = busy;
                     button.setAttribute('aria-busy', String(busy));
@@ -209,14 +205,9 @@ const websiteSchema = {
                 }
             };
 
-            document.addEventListener('click', event => {
-                const button = (event.target as Element | null)?.closest<HTMLButtonElement>('[data-random-post]');
-                if (button) void goToRandomPost();
-            });
-
-            document.addEventListener('astro:page-load', () => {
-                randomPostLoading = false;
-            });
+            for (const button of randomPostButtons) {
+                button.addEventListener('click', () => void goToRandomPost());
+            }
 
             if (import.meta.env.PROD && 'serviceWorker' in navigator) {
                 window.addEventListener('load', () => {
@@ -230,6 +221,15 @@ const websiteSchema = {
 </html>
 
 <style>
+    @view-transition {
+        navigation: auto;
+    }
+
+    ::view-transition-old(root),
+    ::view-transition-new(root) {
+        animation-duration: 120ms;
+    }
+
     .layout {
         display: flex;
         min-height: 100vh;
@@ -392,6 +392,13 @@ const websiteSchema = {
         color: var(--color-primary);
         background: var(--color-primary-soft);
         border-color: var(--color-primary);
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        ::view-transition-old(root),
+        ::view-transition-new(root) {
+            animation-duration: 0s;
+        }
     }
 
     @media (max-width: 900px) {

--- a/src/scripts/listPage.ts
+++ b/src/scripts/listPage.ts
@@ -6,25 +6,38 @@ type ListMode = 'character' | 'artist';
 
 const initializeListPage = (): void => {
     const root = document.querySelector<HTMLElement>('[data-list-page]');
-    const dataElement = root?.querySelector<HTMLScriptElement>('[data-list-data]');
-    if (!root || !dataElement || root.dataset.initialized === 'true') return;
-    root.dataset.initialized = 'true';
+    if (!root) return;
 
     const mode = root.dataset.mode as ListMode;
-    const items = JSON.parse(dataElement.textContent ?? '[]') as ListItem[];
     const searchInput = root.querySelector<HTMLInputElement>('[data-list-search]');
     const grid = root.querySelector<HTMLUListElement>('[data-list-grid]');
     const sortButton = root.querySelector<HTMLButtonElement>('[data-list-sort]');
     const selectModeButton = root.querySelector<HTMLButtonElement>('[data-select-mode]');
     const viewSelectedLink = root.querySelector<HTMLAnchorElement>('[data-view-selected]');
     const loadMoreButton = root.querySelector<HTMLButtonElement>('[data-load-more]');
-    const pageSize = 50;
+    const pageSize = Number(root.dataset.pageSize) || 24;
 
+    let itemsRequest: Promise<ListItem[]> | undefined;
     let searchValue = '';
     let isSelectMode = false;
     let selectedItems: string[] = [];
     let sortOrder: SortOrder = mode === 'artist' ? 'desc' : 'none';
     let visibleCount = pageSize;
+
+    const loadItems = (): Promise<ListItem[]> => {
+        itemsRequest ??= fetch(assetPath(`runtime-data/${mode === 'artist' ? 'artists' : 'characters'}.json`))
+            .then(async response => {
+                if (!response.ok) throw new Error(`List data request failed with ${response.status}.`);
+                const value: unknown = await response.json();
+                if (!Array.isArray(value)) throw new TypeError('List data response was invalid.');
+                return value as ListItem[];
+            })
+            .catch(error => {
+                itemsRequest = undefined;
+                throw error;
+            });
+        return itemsRequest;
+    };
 
     const compareItems = (left: ListItem, right: ListItem): number => {
         if (sortOrder === 'none') return mode === 'artist' ? left.id.localeCompare(right.id) : 0;
@@ -65,7 +78,7 @@ const initializeListPage = (): void => {
             box.setAttribute('aria-pressed', String(selected));
             box.addEventListener('click', () => {
                 selectedItems = selected ? selectedItems.filter(id => id !== item.id) : [...selectedItems, item.id];
-                render();
+                void renderLoadedItems();
             });
         } else {
             box.href = selectedGalleryUrl(item.id);
@@ -106,7 +119,7 @@ const initializeListPage = (): void => {
         return listItem;
     };
 
-    const render = (): void => {
+    const render = (items: ListItem[]): void => {
         if (!grid || !sortButton || !loadMoreButton) return;
         const query = searchValue.toLocaleLowerCase();
         const searchedItems = query
@@ -130,13 +143,27 @@ const initializeListPage = (): void => {
         }
     };
 
-    searchInput?.addEventListener('input', () => { searchValue = searchInput.value; render(); });
-    sortButton?.addEventListener('click', () => { sortOrder = sortOrder === 'none' ? 'desc' : sortOrder === 'desc' ? 'asc' : 'none'; render(); });
-    selectModeButton?.addEventListener('click', () => { isSelectMode = !isSelectMode; render(); });
-    loadMoreButton?.addEventListener('click', () => { visibleCount += pageSize; render(); });
+    const reportLoadError = (error: unknown): void => console.error('Unable to load list data.', error);
+    const renderLoadedItems = async (): Promise<void> => render(await loadItems());
 
-    render();
+    searchInput?.addEventListener('input', () => {
+        searchValue = searchInput.value;
+        visibleCount = pageSize;
+        void renderLoadedItems().catch(reportLoadError);
+    });
+    sortButton?.addEventListener('click', () => {
+        sortOrder = sortOrder === 'none' ? 'desc' : sortOrder === 'desc' ? 'asc' : 'none';
+        visibleCount = pageSize;
+        void renderLoadedItems().catch(reportLoadError);
+    });
+    selectModeButton?.addEventListener('click', () => {
+        isSelectMode = !isSelectMode;
+        void renderLoadedItems().catch(reportLoadError);
+    });
+    loadMoreButton?.addEventListener('click', () => {
+        visibleCount += pageSize;
+        void renderLoadedItems().catch(reportLoadError);
+    });
 };
 
-document.addEventListener('astro:page-load', initializeListPage);
 initializeListPage();

--- a/tests/e2e/spa.spec.ts
+++ b/tests/e2e/spa.spec.ts
@@ -1,16 +1,21 @@
 import { expect, test } from '@playwright/test';
 
-test('adjacent post browsing stays in the Astro client router', async ({ page }) => {
+test('archive routes use native document navigation consistently', async ({ page }) => {
     await page.goto('gallery/', { waitUntil: 'domcontentloaded' });
 
-    // Gallery intentionally stays a plain static page. Entering a post may replace
-    // the document; only sequential post-to-post browsing needs SPA semantics.
+    await page.evaluate(() => {
+        (window as Window & { __documentMarker?: string }).__documentMarker = 'gallery';
+    });
+
     await page.locator('[data-gallery-grid] a.tile').first().click();
     await expect(page).toHaveURL(/\/touhou-translations\/posts\/[^/]+\/$/);
     await expect(page.locator('.artist-pill')).toBeVisible();
+    expect(await page.evaluate(() =>
+        (window as Window & { __documentMarker?: string }).__documentMarker
+    )).toBeUndefined();
 
     await page.evaluate(() => {
-        (window as Window & { __spaNavigationMarker?: string }).__spaNavigationMarker = 'alive';
+        (window as Window & { __documentMarker?: string }).__documentMarker = 'post';
     });
 
     const adjacent = page.locator('.links a').filter({ hasText: /^(Previous|Next)$/ }).first();
@@ -20,15 +25,11 @@ test('adjacent post browsing stays in the Astro client router', async ({ page })
     await expect(page).not.toHaveURL(firstPostUrl);
     await expect(page.locator('.artist-pill')).toBeVisible();
     expect(await page.evaluate(() =>
-        (window as Window & { __spaNavigationMarker?: string }).__spaNavigationMarker
-    )).toBe('alive');
+        (window as Window & { __documentMarker?: string }).__documentMarker
+    )).toBeUndefined();
 
-    // Leaving the post section intentionally returns to ordinary document navigation.
     await page.getByRole('link', { name: 'Gallery', exact: true }).first().click();
     await expect(page).toHaveURL(/\/touhou-translations\/gallery\/$/);
-    expect(await page.evaluate(() =>
-        (window as Window & { __spaNavigationMarker?: string }).__spaNavigationMarker
-    )).toBeUndefined();
 
     const contentFilter = page.getByRole('button', { name: 'All Posts' });
     await contentFilter.click();


### PR DESCRIPTION
Reworks navigation around Astro's static strengths so every public route uses one fast model without shipping ClientRouter.

- removes Astro ClientRouter and restores normal document navigation everywhere
- enables universal hover/focus intent prefetch through Astro
- adds native cross-document View Transitions as progressive enhancement
- replaces the post-only service-worker strategy with uniform navigation caching for all routes
- enables Navigation Preload so freshness requests can start alongside service-worker startup
- removes blind Previous/Next warming in favor of intent-driven prefetch
- versions runtime caches against all built HTML and runtime JSON
- publishes artists/characters runtime JSON instead of embedding the complete datasets in list-page HTML
- reduces initial list SSR from 50 cards to 24, preserves that SSR DOM, and loads the full list only on search/sort/select/load-more
- adds content-visibility containment for offscreen list cards
- updates E2E coverage to require native document navigation consistently

This is intended to improve both cold PageSpeed characteristics and real internal navigation latency rather than trading one against the other.