### PR TITLE
perf: trim post critical request chain

### DIFF
--- a/src/components/home/FeaturedVideo.astro
+++ b/src/components/home/FeaturedVideo.astro
@@ -9,27 +9,19 @@
 </section>
 
 <script>
-    const initializeFeaturedVideo = (): void => {
-        const root = document.querySelector<HTMLElement>('[data-featured-video]');
-        if (!root || root.dataset.initialized === 'true') return;
-        root.dataset.initialized = 'true';
+    const root = document.querySelector<HTMLElement>('[data-featured-video]');
+    const poster = root?.querySelector<HTMLButtonElement>('[data-video-poster]');
+    const frame = root?.querySelector<HTMLElement>('.video-frame');
 
-        const poster = root.querySelector<HTMLButtonElement>('[data-video-poster]');
-        const frame = root.querySelector<HTMLElement>('.video-frame');
-
-        poster?.addEventListener('click', () => {
-            if (!frame) return;
-            const iframe = document.createElement('iframe');
-            iframe.src = 'https://www.youtube-nocookie.com/embed/Gfev_ZEBRNk?autoplay=1';
-            iframe.title = 'Featured Video';
-            iframe.allow = 'autoplay; encrypted-media; picture-in-picture; web-share';
-            iframe.allowFullscreen = true;
-            frame.replaceChildren(iframe);
-        }, { once: true });
-    };
-
-    document.addEventListener('astro:page-load', initializeFeaturedVideo);
-    initializeFeaturedVideo();
+    poster?.addEventListener('click', () => {
+        if (!frame) return;
+        const iframe = document.createElement('iframe');
+        iframe.src = 'https://www.youtube-nocookie.com/embed/Gfev_ZEBRNk?autoplay=1';
+        iframe.title = 'Featured Video';
+        iframe.allow = 'autoplay; encrypted-media; picture-in-picture; web-share';
+        iframe.allowFullscreen = true;
+        frame.replaceChildren(iframe);
+    }, { once: true });
 </script>
 
 <style is:global>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -55,11 +55,6 @@ const resolvedPreconnectOrigins = preconnectOrigins ?? (
         ? ['https://i.redd.it', 'https://preview.redd.it']
         : []
 );
-const postIdsUrl = assetPath('post-ids.json');
-const postsBaseUrl = pagePath('posts');
-const serviceWorkerUrl = assetPath('service-worker.js');
-const serviceWorkerScope = pagePath();
-const isProduction = import.meta.env.PROD;
 ---
 
 <!doctype html>
@@ -166,64 +161,73 @@ const isProduction = import.meta.env.PROD;
             </footer>
         </div>
 
-        <script is:inline define:vars={{ postIdsUrl, postsBaseUrl, serviceWorkerUrl, serviceWorkerScope, isProduction }}>
-            (() => {
-                let postIdRequest;
-                let randomPostLoading = false;
-                const randomPostButtons = [...document.querySelectorAll('[data-random-post]')];
+        <script>
+            const baseUrl = import.meta.env.BASE_URL.endsWith('/')
+                ? import.meta.env.BASE_URL
+                : `${import.meta.env.BASE_URL}/`;
+            const postIdsUrl = `${baseUrl}post-ids.json`;
+            const postsBaseUrl = `${baseUrl}posts/`;
+            const serviceWorkerUrl = `${baseUrl}service-worker.js`;
+            const serviceWorkerScope = baseUrl;
 
-                const setRandomPostState = (label, busy) => {
-                    for (const button of randomPostButtons) {
-                        button.textContent = label;
-                        button.disabled = busy;
-                        button.setAttribute('aria-busy', String(busy));
-                    }
-                };
+            let postIdRequest: Promise<string[]> | undefined;
+            let randomPostLoading = false;
+            const randomPostButtons = [...document.querySelectorAll<HTMLButtonElement>('[data-random-post]')];
 
-                const fetchRandomPostIds = () => {
-                    postIdRequest ??= fetch(postIdsUrl)
-                        .then(async response => {
-                            if (!response.ok) throw new Error(`Post index request failed with ${response.status}.`);
-                            const value = await response.json();
-                            if (!Array.isArray(value) || !value.every(id => typeof id === 'string')) {
-                                throw new TypeError('Post index response was invalid.');
-                            }
-                            return value;
-                        })
-                        .catch(error => {
-                            postIdRequest = undefined;
-                            throw error;
-                        });
-                    return postIdRequest;
-                };
-
-                const goToRandomPost = async () => {
-                    if (randomPostLoading) return;
-                    randomPostLoading = true;
-                    setRandomPostState('Loading…', true);
-
-                    try {
-                        const postIds = await fetchRandomPostIds();
-                        if (postIds.length === 0) throw new Error('No posts are available.');
-                        const id = postIds[Math.floor(Math.random() * postIds.length)];
-                        window.location.assign(`${postsBaseUrl}${encodeURIComponent(id)}/`);
-                    } catch (error) {
-                        console.error('Unable to open a random post.', error);
-                        randomPostLoading = false;
-                        setRandomPostState('Retry', false);
-                    }
-                };
-
+            const setRandomPostState = (label: string, busy: boolean): void => {
                 for (const button of randomPostButtons) {
-                    button.addEventListener('click', () => void goToRandomPost());
+                    button.textContent = label;
+                    button.disabled = busy;
+                    button.setAttribute('aria-busy', String(busy));
                 }
+            };
 
-                if (isProduction && 'serviceWorker' in navigator) {
-                    window.addEventListener('load', () => {
-                        void navigator.serviceWorker.register(serviceWorkerUrl, { scope: serviceWorkerScope });
-                    }, { once: true });
+            const fetchRandomPostIds = (): Promise<string[]> => {
+                postIdRequest ??= fetch(postIdsUrl)
+                    .then(async response => {
+                        if (!response.ok) throw new Error(`Post index request failed with ${response.status}.`);
+                        const value: unknown = await response.json();
+                        if (!Array.isArray(value) || !value.every(id => typeof id === 'string')) {
+                            throw new TypeError('Post index response was invalid.');
+                        }
+                        return value;
+                    })
+                    .catch(error => {
+                        postIdRequest = undefined;
+                        throw error;
+                    });
+
+                return postIdRequest;
+            };
+
+            const goToRandomPost = async (): Promise<void> => {
+                if (randomPostLoading) return;
+                randomPostLoading = true;
+                setRandomPostState('Loading…', true);
+
+                try {
+                    const postIds = await fetchRandomPostIds();
+                    if (postIds.length === 0) throw new Error('No posts are available.');
+                    const id = postIds[Math.floor(Math.random() * postIds.length)];
+                    window.location.assign(`${postsBaseUrl}${encodeURIComponent(id)}/`);
+                } catch (error) {
+                    console.error('Unable to open a random post.', error);
+                    randomPostLoading = false;
+                    setRandomPostState('Retry', false);
                 }
-            })();
+            };
+
+            for (const button of randomPostButtons) {
+                button.addEventListener('click', () => void goToRandomPost());
+            }
+
+            if (import.meta.env.PROD && 'serviceWorker' in navigator) {
+                window.addEventListener('load', () => {
+                    void navigator.serviceWorker.register(serviceWorkerUrl, {
+                        scope: serviceWorkerScope
+                    });
+                }, { once: true });
+            }
         </script>
     </body>
 </html>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -12,6 +12,7 @@ interface Props {
     ogImage?: string;
     currentSection?: 'home' | 'characters' | 'artists' | 'gallery' | 'post';
     noindex?: boolean;
+    preconnectOrigins?: string[];
 }
 
 const {
@@ -22,7 +23,8 @@ const {
     ogType = 'website',
     ogImage,
     currentSection,
-    noindex = false
+    noindex = false,
+    preconnectOrigins
 } = Astro.props;
 
 const links = [
@@ -47,6 +49,17 @@ const websiteSchema = {
     url: 'https://aenigmatrices.github.io/touhou-translations/',
     description: DEFAULT_DESCRIPTION
 };
+
+const resolvedPreconnectOrigins = preconnectOrigins ?? (
+    currentSection === 'home' || currentSection === 'gallery'
+        ? ['https://i.redd.it', 'https://preview.redd.it']
+        : []
+);
+const postIdsUrl = assetPath('post-ids.json');
+const postsBaseUrl = pagePath('posts');
+const serviceWorkerUrl = assetPath('service-worker.js');
+const serviceWorkerScope = pagePath();
+const isProduction = import.meta.env.PROD;
 ---
 
 <!doctype html>
@@ -65,8 +78,7 @@ const websiteSchema = {
         <link rel="manifest" href={assetPath('manifest.webmanifest')} />
         <link rel="icon" href={assetPath('favicon.ico')} type="image/x-icon" />
         <link rel="apple-touch-icon" href={assetPath('icons/pwa/pwa-icon-192x192.png')} />
-        <link rel="preconnect" href="https://i.redd.it" />
-        <link rel="preconnect" href="https://preview.redd.it" />
+        {resolvedPreconnectOrigins.map(origin => <link rel="preconnect" href={origin} />)}
         <meta property="og:site_name" content={SITE_NAME} />
         <meta property="og:title" content={ogTitle} />
         <meta property="og:description" content={description} />
@@ -154,68 +166,64 @@ const websiteSchema = {
             </footer>
         </div>
 
-        <script>
-            import { assetPath, pagePath } from '../utils/paths';
+        <script is:inline define:vars={{ postIdsUrl, postsBaseUrl, serviceWorkerUrl, serviceWorkerScope, isProduction }}>
+            (() => {
+                let postIdRequest;
+                let randomPostLoading = false;
+                const randomPostButtons = [...document.querySelectorAll('[data-random-post]')];
 
-            let postIdRequest: Promise<string[]> | undefined;
-            let randomPostLoading = false;
+                const setRandomPostState = (label, busy) => {
+                    for (const button of randomPostButtons) {
+                        button.textContent = label;
+                        button.disabled = busy;
+                        button.setAttribute('aria-busy', String(busy));
+                    }
+                };
 
-            const randomPostButtons = [...document.querySelectorAll<HTMLButtonElement>('[data-random-post]')];
+                const fetchRandomPostIds = () => {
+                    postIdRequest ??= fetch(postIdsUrl)
+                        .then(async response => {
+                            if (!response.ok) throw new Error(`Post index request failed with ${response.status}.`);
+                            const value = await response.json();
+                            if (!Array.isArray(value) || !value.every(id => typeof id === 'string')) {
+                                throw new TypeError('Post index response was invalid.');
+                            }
+                            return value;
+                        })
+                        .catch(error => {
+                            postIdRequest = undefined;
+                            throw error;
+                        });
+                    return postIdRequest;
+                };
 
-            const setRandomPostState = (label: string, busy: boolean): void => {
+                const goToRandomPost = async () => {
+                    if (randomPostLoading) return;
+                    randomPostLoading = true;
+                    setRandomPostState('Loading…', true);
+
+                    try {
+                        const postIds = await fetchRandomPostIds();
+                        if (postIds.length === 0) throw new Error('No posts are available.');
+                        const id = postIds[Math.floor(Math.random() * postIds.length)];
+                        window.location.assign(`${postsBaseUrl}${encodeURIComponent(id)}/`);
+                    } catch (error) {
+                        console.error('Unable to open a random post.', error);
+                        randomPostLoading = false;
+                        setRandomPostState('Retry', false);
+                    }
+                };
+
                 for (const button of randomPostButtons) {
-                    button.textContent = label;
-                    button.disabled = busy;
-                    button.setAttribute('aria-busy', String(busy));
+                    button.addEventListener('click', () => void goToRandomPost());
                 }
-            };
 
-            const fetchRandomPostIds = (): Promise<string[]> => {
-                postIdRequest ??= fetch(assetPath('post-ids.json'))
-                    .then(async response => {
-                        if (!response.ok) throw new Error(`Post index request failed with ${response.status}.`);
-                        const value: unknown = await response.json();
-                        if (!Array.isArray(value) || !value.every(id => typeof id === 'string')) {
-                            throw new TypeError('Post index response was invalid.');
-                        }
-                        return value;
-                    })
-                    .catch(error => {
-                        postIdRequest = undefined;
-                        throw error;
-                    });
-
-                return postIdRequest;
-            };
-
-            const goToRandomPost = async (): Promise<void> => {
-                if (randomPostLoading) return;
-                randomPostLoading = true;
-                setRandomPostState('Loading…', true);
-
-                try {
-                    const postIds = await fetchRandomPostIds();
-                    if (postIds.length === 0) throw new Error('No posts are available.');
-                    const id = postIds[Math.floor(Math.random() * postIds.length)];
-                    window.location.assign(pagePath(`posts/${id}`));
-                } catch (error) {
-                    console.error('Unable to open a random post.', error);
-                    randomPostLoading = false;
-                    setRandomPostState('Retry', false);
+                if (isProduction && 'serviceWorker' in navigator) {
+                    window.addEventListener('load', () => {
+                        void navigator.serviceWorker.register(serviceWorkerUrl, { scope: serviceWorkerScope });
+                    }, { once: true });
                 }
-            };
-
-            for (const button of randomPostButtons) {
-                button.addEventListener('click', () => void goToRandomPost());
-            }
-
-            if (import.meta.env.PROD && 'serviceWorker' in navigator) {
-                window.addEventListener('load', () => {
-                    void navigator.serviceWorker.register(assetPath('service-worker.js'), {
-                        scope: pagePath()
-                    });
-                }, { once: true });
-            }
+            })();
         </script>
     </body>
 </html>

--- a/src/pages/posts/[id].astro
+++ b/src/pages/posts/[id].astro
@@ -25,6 +25,16 @@ const canonicalUrl = absoluteSiteUrl(`posts/${data.id}`);
 const socialImage = !data.post.nsfw
     ? data.post.url[0]
     : absoluteSiteUrl('icons/touhou-translations-profile-icon.png');
+const preconnectOrigins = [...new Set([
+    data.post.url[0],
+    ...(data.post.imageSources?.[0] ?? []).map(source => source.url)
+].flatMap(url => {
+    try {
+        return [new URL(url).origin];
+    } catch {
+        return [];
+    }
+}).filter(origin => origin === 'https://i.redd.it' || origin === 'https://preview.redd.it'))];
 ---
 
 <BaseLayout
@@ -35,6 +45,7 @@ const socialImage = !data.post.nsfw
     ogType="article"
     ogImage={socialImage}
     currentSection="post"
+    {preconnectOrigins}
 >
     <section class="post-page" data-post-page>
         <div class="images">
@@ -72,8 +83,8 @@ const socialImage = !data.post.nsfw
                 <div class="links">
                     <a href={data.post.reddit} target="_blank" rel="noopener noreferrer">Reddit</a>
                     <a href={data.post.src} target="_blank" rel="noopener noreferrer">Source</a>
-                    {data.prevPostId && <a href={pagePath(`posts/${data.prevPostId}`)} data-astro-prefetch="viewport">Previous</a>}
-                    {data.nextPostId && <a href={pagePath(`posts/${data.nextPostId}`)} data-astro-prefetch="viewport">Next</a>}
+                    {data.prevPostId && <a href={pagePath(`posts/${data.prevPostId}`)}>Previous</a>}
+                    {data.nextPostId && <a href={pagePath(`posts/${data.nextPostId}`)}>Next</a>}
                 </div>
                 {data.post.nsfw && (
                     <button class="uncensor-button" type="button" aria-pressed="false" data-nsfw-toggle>
@@ -133,44 +144,34 @@ const socialImage = !data.post.nsfw
         </aside>
     </section>
 
-    <script>
-        let cleanupPostPage: (() => void) | undefined;
+    <script is:inline>
+        (() => {
+            const root = document.querySelector('[data-post-page]');
+            if (!root) return;
 
-        const initializePostPage = (): void => {
-            const root = document.querySelector<HTMLElement>('[data-post-page]');
-            if (!root) {
-                cleanupPostPage?.();
-                cleanupPostPage = undefined;
-                return;
-            }
-            if (root.dataset.initialized === 'true') return;
-
-            cleanupPostPage?.();
-            root.dataset.initialized = 'true';
-
-            const toggle = root.querySelector<HTMLButtonElement>('[data-nsfw-toggle]');
-            const morePanel = root.querySelector<HTMLDetailsElement>('[data-more-panel]');
-            const moreGrid = morePanel?.querySelector<HTMLElement>('[data-more-grid]');
-            const moreTemplate = morePanel?.querySelector<HTMLTemplateElement>('[data-more-template]');
-            const moreAction = morePanel?.querySelector<HTMLElement>('[data-more-action]');
-            const moreSummary = morePanel?.querySelector<HTMLElement>('summary');
+            const toggle = root.querySelector('[data-nsfw-toggle]');
+            const morePanel = root.querySelector('[data-more-panel]');
+            const moreGrid = morePanel?.querySelector('[data-more-grid]');
+            const moreTemplate = morePanel?.querySelector('[data-more-template]');
+            const moreAction = morePanel?.querySelector('[data-more-action]');
+            const moreSummary = morePanel?.querySelector('summary');
             const mobileLayout = window.matchMedia('(max-width: 900px)');
             let revealed = false;
             let moreImagesLoaded = false;
 
-            const loadMoreImages = (): void => {
+            const loadMoreImages = () => {
                 if (moreImagesLoaded || !moreGrid || !moreTemplate) return;
                 moreGrid.append(moreTemplate.content.cloneNode(true));
                 moreImagesLoaded = true;
 
                 if (revealed) {
-                    for (const image of moreGrid.querySelectorAll<HTMLElement>('[data-nsfw-image]')) {
+                    for (const image of moreGrid.querySelectorAll('[data-nsfw-image]')) {
                         image.classList.remove('nsfw');
                     }
                 }
             };
 
-            const updateMorePanel = (): void => {
+            const updateMorePanel = () => {
                 if (!morePanel) return;
                 if (!mobileLayout.matches) {
                     morePanel.open = true;
@@ -179,40 +180,24 @@ const socialImage = !data.post.nsfw
                 if (moreAction) moreAction.textContent = morePanel.open ? 'Hide' : 'Show';
             };
 
-            const onToggle = (): void => {
-                if (morePanel?.open) loadMoreImages();
+            morePanel?.addEventListener('toggle', () => {
+                if (morePanel.open) loadMoreImages();
                 updateMorePanel();
-            };
-            const onSummaryClick = (event: MouseEvent): void => {
+            });
+            moreSummary?.addEventListener('click', event => {
                 if (!mobileLayout.matches) event.preventDefault();
-            };
-            const onToggleNsfw = (): void => {
+            });
+            mobileLayout.addEventListener('change', updateMorePanel);
+            toggle?.addEventListener('click', () => {
                 revealed = !revealed;
-                for (const image of root.querySelectorAll<HTMLElement>('[data-nsfw-image]')) {
+                for (const image of root.querySelectorAll('[data-nsfw-image]')) {
                     image.classList.toggle('nsfw', !revealed);
                 }
-                if (toggle) {
-                    toggle.setAttribute('aria-pressed', String(revealed));
-                    toggle.textContent = revealed ? 'Censor images' : 'Uncensor images';
-                }
-            };
-
-            morePanel?.addEventListener('toggle', onToggle);
-            moreSummary?.addEventListener('click', onSummaryClick);
-            mobileLayout.addEventListener('change', updateMorePanel);
-            toggle?.addEventListener('click', onToggleNsfw);
+                toggle.setAttribute('aria-pressed', String(revealed));
+                toggle.textContent = revealed ? 'Censor images' : 'Uncensor images';
+            });
             updateMorePanel();
-
-            cleanupPostPage = () => {
-                morePanel?.removeEventListener('toggle', onToggle);
-                moreSummary?.removeEventListener('click', onSummaryClick);
-                mobileLayout.removeEventListener('change', updateMorePanel);
-                toggle?.removeEventListener('click', onToggleNsfw);
-            };
-        };
-
-        document.addEventListener('astro:page-load', initializePostPage);
-        initializePostPage();
+        })();
     </script>
 </BaseLayout>
 
@@ -244,7 +229,7 @@ const socialImage = !data.post.nsfw
     .more-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.55rem; }
     .more-panel summary { list-style: none; }
     .more-panel summary::-webkit-details-marker { display: none; }
-    .more-panel summary .eyebrow { margin-bottom: 0.35rem; }
+    .more-panel summary .eyrow { margin-bottom: 0.35rem; }
     .more-action { display: none; }
     .more-grid a { overflow: hidden; aspect-ratio: 1; border-radius: var(--radius-md); }
     .more-grid img { display: block; width: 100%; height: 100%; object-fit: cover; }
@@ -258,9 +243,4 @@ const socialImage = !data.post.nsfw
         .more-action { display: inline; color: var(--color-primary); font-size: 0.86rem; font-weight: 800; }
         .more-panel[open] summary { margin-bottom: 0.55rem; }
     }
-</style>
-
-<style is:global>
-    .post-page .prose p:first-child { margin-top: 0; }
-    .post-page .prose p:last-child { margin-bottom: 0; }
 </style>

--- a/src/pages/posts/[id].astro
+++ b/src/pages/posts/[id].astro
@@ -229,7 +229,7 @@ const preconnectOrigins = [...new Set([
     .more-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.55rem; }
     .more-panel summary { list-style: none; }
     .more-panel summary::-webkit-details-marker { display: none; }
-    .more-panel summary .eyrow { margin-bottom: 0.35rem; }
+    .more-panel summary .eyebrow { margin-bottom: 0.35rem; }
     .more-action { display: none; }
     .more-grid a { overflow: hidden; aspect-ratio: 1; border-radius: var(--radius-md); }
     .more-grid img { display: block; width: 100%; height: 100%; object-fit: cover; }

--- a/src/pages/posts/[id].astro
+++ b/src/pages/posts/[id].astro
@@ -144,34 +144,32 @@ const preconnectOrigins = [...new Set([
         </aside>
     </section>
 
-    <script is:inline>
-        (() => {
-            const root = document.querySelector('[data-post-page]');
-            if (!root) return;
-
-            const toggle = root.querySelector('[data-nsfw-toggle]');
-            const morePanel = root.querySelector('[data-more-panel]');
-            const moreGrid = morePanel?.querySelector('[data-more-grid]');
-            const moreTemplate = morePanel?.querySelector('[data-more-template]');
-            const moreAction = morePanel?.querySelector('[data-more-action]');
-            const moreSummary = morePanel?.querySelector('summary');
+    <script>
+        const root = document.querySelector<HTMLElement>('[data-post-page]');
+        if (root) {
+            const toggle = root.querySelector<HTMLButtonElement>('[data-nsfw-toggle]');
+            const morePanel = root.querySelector<HTMLDetailsElement>('[data-more-panel]');
+            const moreGrid = morePanel?.querySelector<HTMLElement>('[data-more-grid]');
+            const moreTemplate = morePanel?.querySelector<HTMLTemplateElement>('[data-more-template]');
+            const moreAction = morePanel?.querySelector<HTMLElement>('[data-more-action]');
+            const moreSummary = morePanel?.querySelector<HTMLElement>('summary');
             const mobileLayout = window.matchMedia('(max-width: 900px)');
             let revealed = false;
             let moreImagesLoaded = false;
 
-            const loadMoreImages = () => {
+            const loadMoreImages = (): void => {
                 if (moreImagesLoaded || !moreGrid || !moreTemplate) return;
                 moreGrid.append(moreTemplate.content.cloneNode(true));
                 moreImagesLoaded = true;
 
                 if (revealed) {
-                    for (const image of moreGrid.querySelectorAll('[data-nsfw-image]')) {
+                    for (const image of moreGrid.querySelectorAll<HTMLElement>('[data-nsfw-image]')) {
                         image.classList.remove('nsfw');
                     }
                 }
             };
 
-            const updateMorePanel = () => {
+            const updateMorePanel = (): void => {
                 if (!morePanel) return;
                 if (!mobileLayout.matches) {
                     morePanel.open = true;
@@ -190,14 +188,14 @@ const preconnectOrigins = [...new Set([
             mobileLayout.addEventListener('change', updateMorePanel);
             toggle?.addEventListener('click', () => {
                 revealed = !revealed;
-                for (const image of root.querySelectorAll('[data-nsfw-image]')) {
+                for (const image of root.querySelectorAll<HTMLElement>('[data-nsfw-image]')) {
                     image.classList.toggle('nsfw', !revealed);
                 }
                 toggle.setAttribute('aria-pressed', String(revealed));
                 toggle.textContent = revealed ? 'Censor images' : 'Uncensor images';
             });
             updateMorePanel();
-        })();
+        }
     </script>
 </BaseLayout>
 

--- a/src/scripts/dailyPost.ts
+++ b/src/scripts/dailyPost.ts
@@ -15,8 +15,7 @@ const isHomePost = (value: unknown): value is HomePost => {
 
 const initializeDailyPost = (): void => {
     const root = document.querySelector<HTMLElement>('[data-daily-post]');
-    if (!root || root.dataset.initialized === 'true') return;
-    root.dataset.initialized = 'true';
+    if (!root) return;
 
     const link = root.querySelector<HTMLAnchorElement>('[data-daily-link]');
     const image = root.querySelector<HTMLImageElement>('[data-daily-image]');
@@ -47,5 +46,4 @@ const initializeDailyPost = (): void => {
         });
 };
 
-document.addEventListener('astro:page-load', initializeDailyPost);
 initializeDailyPost();

--- a/src/scripts/gallery.ts
+++ b/src/scripts/gallery.ts
@@ -24,8 +24,7 @@ const loadPosts = (): Promise<GalleryPost[]> => {
 
 const initializeGallery = (): void => {
     const root = document.querySelector<HTMLElement>('[data-gallery-page]');
-    if (!root || root.dataset.initialized === 'true') return;
-    root.dataset.initialized = 'true';
+    if (!root) return;
 
     const postsPerPage = 12;
     const grid = root.querySelector<HTMLElement>('[data-gallery-grid]');
@@ -206,5 +205,4 @@ const initializeGallery = (): void => {
     if (characterQueries.length > 0 || artistQueries.length > 0 || search.has('mode')) void render().catch(reportLoadError);
 };
 
-document.addEventListener('astro:page-load', initializeGallery);
 initializeGallery();


### PR DESCRIPTION
Targets the remaining non-image PageSpeed overhead without changing the artwork/WebP pipeline.

- removes obsolete `astro:page-load` lifecycle handling left over from ClientRouter
- inlines the tiny shared layout runtime so Random Post/service-worker setup no longer creates a BaseLayout -> paths.js request chain
- inlines the post interaction runtime
- makes Reddit preconnects route-specific and, on post pages, derives them from the actual first-image origins
- removes stale viewport prefetching from Previous/Next so adjacent HTML does not compete with the LCP artwork before user intent
- keeps the global hover-intent prefetch strategy from the native navigation architecture

No artwork format conversion or build-time WebP generation is included in this PR.