### PR TITLE
perf: prioritize mobile post LCP

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -74,6 +74,7 @@ const resolvedPreconnectOrigins = preconnectOrigins ?? (
         <link rel="icon" href={assetPath('favicon.ico')} type="image/x-icon" />
         <link rel="apple-touch-icon" href={assetPath('icons/pwa/pwa-icon-192x192.png')} />
         {resolvedPreconnectOrigins.map(origin => <link rel="preconnect" href={origin} />)}
+        <slot name="head" />
         <meta property="og:site_name" content={SITE_NAME} />
         <meta property="og:title" content={ogTitle} />
         <meta property="og:description" content={description} />

--- a/src/pages/posts/[id].astro
+++ b/src/pages/posts/[id].astro
@@ -3,7 +3,7 @@ import type { GetStaticPaths } from 'astro';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { getPostIds, getPostPageData } from '../../lib/server/postPageData';
 import { assetPath, pagePath, pagePathWithQuery } from '../../utils/paths';
-import { responsiveSrcset } from '../../utils/responsiveImage';
+import { boundedResponsiveSrcset, responsiveSrcset } from '../../utils/responsiveImage';
 import { absoluteSiteUrl } from '../../utils/siteMetadata';
 
 export const getStaticPaths = (async () => (
@@ -25,16 +25,34 @@ const canonicalUrl = absoluteSiteUrl(`posts/${data.id}`);
 const socialImage = !data.post.nsfw
     ? data.post.url[0]
     : absoluteSiteUrl('icons/touhou-translations-profile-icon.png');
-const preconnectOrigins = [...new Set([
-    data.post.url[0],
-    ...(data.post.imageSources?.[0] ?? []).map(source => source.url)
-].flatMap(url => {
+
+const mobileImageMaxWidth = 1080;
+const mobileImageSizes = 'calc(100vw - 2rem)';
+const desktopImageSizes = 'min(1050px, calc(100vw - 490px))';
+const imageSizes = `(max-width: 900px) ${mobileImageSizes}, ${desktopImageSizes}`;
+const firstImageUrl = data.post.url[0];
+const firstImageDimensions = data.post.imageDimensions?.[0];
+const firstImageSources = data.post.imageSources?.[0];
+const firstImageSrcset = responsiveSrcset(firstImageSources, firstImageUrl, firstImageDimensions?.width);
+const firstMobileSrcset = boundedResponsiveSrcset(
+    firstImageSources,
+    firstImageUrl,
+    firstImageDimensions?.width,
+    mobileImageMaxWidth
+);
+const firstMobileSourceUrls = (firstImageSources ?? [])
+    .filter(source => source.width > 0 && source.width <= mobileImageMaxWidth)
+    .map(source => source.url);
+const preconnectOrigins = [...new Set((
+    firstMobileSourceUrls.length > 0 ? firstMobileSourceUrls : [firstImageUrl]
+).flatMap(url => {
     try {
-        return [new URL(url).origin];
+        const origin = new URL(url).origin;
+        return origin === 'https://i.redd.it' || origin === 'https://preview.redd.it' ? [origin] : [];
     } catch {
         return [];
     }
-}).filter(origin => origin === 'https://i.redd.it' || origin === 'https://preview.redd.it'))];
+}))];
 ---
 
 <BaseLayout
@@ -47,26 +65,61 @@ const preconnectOrigins = [...new Set([
     currentSection="post"
     {preconnectOrigins}
 >
+    <Fragment slot="head">
+        <link
+            rel="preload"
+            as="image"
+            href={firstImageUrl}
+            imagesrcset={firstMobileSrcset}
+            imagesizes={mobileImageSizes}
+            media="(max-width: 900px)"
+            fetchpriority="high"
+        />
+        <link
+            rel="preload"
+            as="image"
+            href={firstImageUrl}
+            imagesrcset={firstImageSrcset}
+            imagesizes={desktopImageSizes}
+            media="(min-width: 901px)"
+            fetchpriority="high"
+        />
+    </Fragment>
+
     <section class="post-page" data-post-page>
         <div class="images">
             {data.post.url.map((url, index) => {
                 const dimensions = data.post.imageDimensions?.[index];
                 const sources = data.post.imageSources?.[index];
+                const srcset = responsiveSrcset(sources, url, dimensions?.width);
+                const mobileSrcset = index === 0
+                    ? firstMobileSrcset
+                    : undefined;
+
                 return (
                     <figure>
-                        <img
-                            class:list={{ nsfw: data.post.nsfw }}
-                            src={url}
-                            srcset={responsiveSrcset(sources, url, dimensions?.width)}
-                            sizes="(max-width: 900px) calc(100vw - 2rem), min(1050px, calc(100vw - 490px))"
-                            alt={`Translated artwork page ${index + 1}`}
-                            width={dimensions?.width}
-                            height={dimensions?.height}
-                            loading={index === 0 ? 'eager' : 'lazy'}
-                            fetchpriority={index === 0 ? 'high' : 'auto'}
-                            decoding="async"
-                            data-nsfw-image={data.post.nsfw ? '' : undefined}
-                        />
+                        <picture>
+                            {mobileSrcset && (
+                                <source
+                                    media="(max-width: 900px)"
+                                    srcset={mobileSrcset}
+                                    sizes={mobileImageSizes}
+                                />
+                            )}
+                            <img
+                                class:list={{ nsfw: data.post.nsfw }}
+                                src={url}
+                                srcset={srcset}
+                                sizes={imageSizes}
+                                alt={`Translated artwork page ${index + 1}`}
+                                width={dimensions?.width}
+                                height={dimensions?.height}
+                                loading={index === 0 ? 'eager' : 'lazy'}
+                                fetchpriority={index === 0 ? 'high' : 'auto'}
+                                decoding={index === 0 ? undefined : 'async'}
+                                data-nsfw-image={data.post.nsfw ? '' : undefined}
+                            />
+                        </picture>
                     </figure>
                 );
             })}
@@ -210,6 +263,7 @@ const preconnectOrigins = [...new Set([
 
     .images { display: grid; gap: 1rem; }
     figure { overflow: hidden; padding: 0; margin: 0; background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--radius-lg); box-shadow: var(--shadow-sm); }
+    figure picture { display: block; }
     figure img { display: block; width: auto; max-width: 100%; height: auto; margin-inline: auto; }
     figure img.nsfw { filter: blur(10px); }
     .info { position: sticky; top: 88px; display: grid; align-self: start; gap: 1rem; }
@@ -235,6 +289,11 @@ const preconnectOrigins = [...new Set([
 
     @media (max-width: 900px) {
         .post-page { grid-template-columns: 1fr; padding: 1rem; }
+        .images figure:not(:first-child),
+        .info > :not(:first-child) {
+            content-visibility: auto;
+            contain-intrinsic-size: auto 420px;
+        }
         .info { position: static; }
         .more-panel summary { display: flex; align-items: center; justify-content: space-between; cursor: pointer; }
         .more-panel summary .eyebrow { margin: 0; }

--- a/src/utils/responsiveImage.test.ts
+++ b/src/utils/responsiveImage.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { responsiveSrcset } from './responsiveImage';
+import { boundedResponsiveSrcset, responsiveSrcset } from './responsiveImage';
 
 describe('responsiveSrcset', () => {
     it('sorts responsive candidates and includes the original fallback width', () => {
@@ -15,5 +15,35 @@ describe('responsiveSrcset', () => {
 
     it('omits srcset when only the fallback candidate is available', () => {
         expect(responsiveSrcset(undefined, 'https://i.redd.it/image.png', 1600)).toBeUndefined();
+    });
+});
+
+describe('boundedResponsiveSrcset', () => {
+    it('keeps existing Reddit candidates at or below the requested maximum width', () => {
+        expect(boundedResponsiveSrcset([
+            { url: 'https://preview.redd.it/image.png?width=320', width: 320 },
+            { url: 'https://preview.redd.it/image.png?width=640', width: 640 },
+            { url: 'https://preview.redd.it/image.png?width=1080', width: 1080 },
+            { url: 'https://preview.redd.it/image.png?width=1440', width: 1440 }
+        ], 'https://i.redd.it/image.png', 2000, 1080)).toBe(
+            'https://preview.redd.it/image.png?width=320 320w, '
+            + 'https://preview.redd.it/image.png?width=640 640w, '
+            + 'https://preview.redd.it/image.png?width=1080 1080w'
+        );
+    });
+
+    it('returns a single bounded candidate when that is all Reddit provides', () => {
+        expect(boundedResponsiveSrcset([
+            { url: 'https://preview.redd.it/image.png?width=960', width: 960 },
+            { url: 'https://preview.redd.it/image.png?width=1440', width: 1440 }
+        ], 'https://i.redd.it/image.png', 2000, 1080)).toBe(
+            'https://preview.redd.it/image.png?width=960 960w'
+        );
+    });
+
+    it('returns undefined when every available candidate exceeds the cap', () => {
+        expect(boundedResponsiveSrcset([
+            { url: 'https://preview.redd.it/image.png?width=1440', width: 1440 }
+        ], 'https://i.redd.it/image.png', 2000, 1080)).toBeUndefined();
     });
 });

--- a/src/utils/responsiveImage.ts
+++ b/src/utils/responsiveImage.ts
@@ -1,19 +1,58 @@
 import type { ResponsiveImageSource } from '../types/data';
 
-export const responsiveSrcset = (
-    sources: ResponsiveImageSource[] | undefined,
-    fallbackUrl: string,
-    fallbackWidth?: number
-): string | undefined => {
-    const candidates = new Map<number, string>();
-    for (const source of sources ?? []) {
-        if (source.width > 0 && source.url) candidates.set(source.width, source.url);
-    }
-    if (fallbackWidth && fallbackWidth > 0) candidates.set(fallbackWidth, fallbackUrl);
-
-    if (candidates.size <= 1) return undefined;
+const serializeCandidates = (candidates: Map<number, string>): string | undefined => {
+    if (candidates.size === 0) return undefined;
     return [...candidates.entries()]
         .sort(([left], [right]) => left - right)
         .map(([width, url]) => `${url} ${width}w`)
         .join(', ');
 };
+
+const collectCandidates = (
+    sources: ResponsiveImageSource[] | undefined,
+    fallbackUrl: string,
+    fallbackWidth?: number,
+    maxWidth?: number
+): Map<number, string> => {
+    const candidates = new Map<number, string>();
+    for (const source of sources ?? []) {
+        if (source.width <= 0 || !source.url) continue;
+        if (maxWidth && source.width > maxWidth) continue;
+        candidates.set(source.width, source.url);
+    }
+
+    if (
+        fallbackWidth
+        && fallbackWidth > 0
+        && (!maxWidth || fallbackWidth <= maxWidth)
+    ) {
+        candidates.set(fallbackWidth, fallbackUrl);
+    }
+
+    return candidates;
+};
+
+export const responsiveSrcset = (
+    sources: ResponsiveImageSource[] | undefined,
+    fallbackUrl: string,
+    fallbackWidth?: number
+): string | undefined => {
+    const candidates = collectCandidates(sources, fallbackUrl, fallbackWidth);
+    if (candidates.size <= 1) return undefined;
+    return serializeCandidates(candidates);
+};
+
+/**
+ * Produces a responsive candidate list capped at a maximum intrinsic width.
+ * Unlike responsiveSrcset(), a single bounded candidate remains useful for a
+ * <source> element because it prevents a mobile browser from selecting a much
+ * larger original image when Reddit already provides a suitable preview.
+ */
+export const boundedResponsiveSrcset = (
+    sources: ResponsiveImageSource[] | undefined,
+    fallbackUrl: string,
+    fallbackWidth: number | undefined,
+    maxWidth: number
+): string | undefined => serializeCandidates(
+    collectCandidates(sources, fallbackUrl, fallbackWidth, maxWidth)
+);


### PR DESCRIPTION
Targets the remaining mobile PageSpeed gap without changing the artwork format or introducing a WebP/build-time image pipeline.

- adds a route-specific head slot for resource hints
- preloads the first post artwork with media-specific responsive metadata
- gives mobile post pages a bounded Reddit candidate set capped at 1080px while preserving the existing full desktop srcset
- keeps the original artwork as the fallback when Reddit has no suitable responsive previews
- narrows post-page preconnects to the origin represented by usable mobile preview candidates, falling back to the original host when needed
- stops forcing async decode on the first LCP image while retaining async decode for later artwork
- adds content-visibility containment only to secondary mobile artwork and below-fold info panels
- adds unit coverage for bounded responsive candidates

No artwork format conversion, local image transformation, or generated WebP assets are included.