### PR TITLE
perf: warm likely navigation destinations after critical content

### DIFF
--- a/src/pages/posts/[id].astro
+++ b/src/pages/posts/[id].astro
@@ -215,7 +215,7 @@ const preconnectOrigins = [...new Set([
                         window.requestIdleCallback(warmAdjacentPosts, { timeout: 2_000 });
                         return;
                     }
-                    window.setTimeout(warmAdjacentPosts, 500);
+                    setTimeout(warmAdjacentPosts, 500);
                 };
 
                 if (!primaryImage || primaryImage.complete) {

--- a/src/pages/posts/[id].astro
+++ b/src/pages/posts/[id].astro
@@ -83,8 +83,8 @@ const preconnectOrigins = [...new Set([
                 <div class="links">
                     <a href={data.post.reddit} target="_blank" rel="noopener noreferrer">Reddit</a>
                     <a href={data.post.src} target="_blank" rel="noopener noreferrer">Source</a>
-                    {data.prevPostId && <a href={pagePath(`posts/${data.prevPostId}`)}>Previous</a>}
-                    {data.nextPostId && <a href={pagePath(`posts/${data.nextPostId}`)}>Next</a>}
+                    {data.prevPostId && <a href={pagePath(`posts/${data.prevPostId}`)} data-adjacent-post>Previous</a>}
+                    {data.nextPostId && <a href={pagePath(`posts/${data.nextPostId}`)} data-adjacent-post>Next</a>}
                 </div>
                 {data.post.nsfw && (
                     <button class="uncensor-button" type="button" aria-pressed="false" data-nsfw-toggle>
@@ -195,6 +195,36 @@ const preconnectOrigins = [...new Set([
                 toggle.textContent = revealed ? 'Censor images' : 'Uncensor images';
             });
             updateMorePanel();
+
+            const connection = (navigator as Navigator & { connection?: { saveData?: boolean } }).connection;
+            if (!connection?.saveData) {
+                const primaryImage = root.querySelector<HTMLImageElement>('.images img');
+                const adjacentLinks = [...root.querySelectorAll<HTMLAnchorElement>('[data-adjacent-post]')];
+                let adjacentPostsWarmed = false;
+
+                const warmAdjacentPosts = (): void => {
+                    if (adjacentPostsWarmed || adjacentLinks.length === 0) return;
+                    adjacentPostsWarmed = true;
+                    for (const link of adjacentLinks) {
+                        void fetch(link.href).catch(() => undefined);
+                    }
+                };
+
+                const scheduleAdjacentWarm = (): void => {
+                    if ('requestIdleCallback' in window) {
+                        window.requestIdleCallback(warmAdjacentPosts, { timeout: 2_000 });
+                        return;
+                    }
+                    window.setTimeout(warmAdjacentPosts, 500);
+                };
+
+                if (!primaryImage || primaryImage.complete) {
+                    scheduleAdjacentWarm();
+                } else {
+                    primaryImage.addEventListener('load', scheduleAdjacentWarm, { once: true });
+                    primaryImage.addEventListener('error', scheduleAdjacentWarm, { once: true });
+                }
+            }
         }
     </script>
 </BaseLayout>

--- a/src/scripts/gallery.ts
+++ b/src/scripts/gallery.ts
@@ -21,7 +21,7 @@ const scheduleIdleTask = (task: () => void): void => {
         window.requestIdleCallback(task, { timeout: 2_000 });
         return;
     }
-    window.setTimeout(task, 500);
+    setTimeout(task, 500);
 };
 
 const warmVisiblePostDocuments = (grid: HTMLElement | null): void => {

--- a/src/scripts/gallery.ts
+++ b/src/scripts/gallery.ts
@@ -4,8 +4,53 @@ import { responsiveSrcset } from '../utils/responsiveImage';
 
 type JumpItem = 'ellipsis-start' | 'ellipsis-end';
 type PaginationItem = number | JumpItem;
+type NavigatorWithConnection = Navigator & {
+    connection?: {
+        saveData?: boolean;
+    };
+};
 
 let postsRequest: Promise<GalleryPost[]> | undefined;
+const warmedPostUrls = new Set<string>();
+
+const shouldAvoidSpeculativeFetch = (): boolean =>
+    Boolean((navigator as NavigatorWithConnection).connection?.saveData);
+
+const scheduleIdleTask = (task: () => void): void => {
+    if ('requestIdleCallback' in window) {
+        window.requestIdleCallback(task, { timeout: 2_000 });
+        return;
+    }
+    window.setTimeout(task, 500);
+};
+
+const warmVisiblePostDocuments = (grid: HTMLElement | null): void => {
+    if (!grid || shouldAvoidSpeculativeFetch()) return;
+
+    scheduleIdleTask(() => {
+        const urls = [...grid.querySelectorAll<HTMLAnchorElement>('a.tile')]
+            .slice(0, 4)
+            .map(link => link.href)
+            .filter(url => !warmedPostUrls.has(url));
+
+        for (const url of urls) {
+            warmedPostUrls.add(url);
+            void fetch(url).catch(() => warmedPostUrls.delete(url));
+        }
+    });
+};
+
+const warmInitialPostDocuments = (grid: HTMLElement | null): void => {
+    const firstImage = grid?.querySelector<HTMLImageElement>('a.tile img');
+    if (!firstImage) {
+        warmVisiblePostDocuments(grid);
+        return;
+    }
+
+    const scheduleWarm = (): void => warmVisiblePostDocuments(grid);
+    if (firstImage.complete) scheduleWarm();
+    else firstImage.addEventListener('load', scheduleWarm, { once: true });
+};
 
 const loadPosts = (): Promise<GalleryPost[]> => {
     postsRequest ??= fetch(assetPath('runtime-data/gallery-posts.json'))
@@ -176,6 +221,7 @@ const initializeGallery = (): void => {
         }
         if (dateSortButton) dateSortButton.textContent = dateSort === 'desc' ? 'Newest First' : 'Oldest First';
         renderPagination(totalPages);
+        warmInitialPostDocuments(grid);
     };
 
     const reportLoadError = (error: unknown): void => console.error('Unable to load gallery data.', error);
@@ -202,7 +248,11 @@ const initializeGallery = (): void => {
         }).catch(reportLoadError);
     });
 
-    if (characterQueries.length > 0 || artistQueries.length > 0 || search.has('mode')) void render().catch(reportLoadError);
+    if (characterQueries.length > 0 || artistQueries.length > 0 || search.has('mode')) {
+        void render().catch(reportLoadError);
+    } else {
+        warmInitialPostDocuments(grid);
+    }
 };
 
 initializeGallery();

--- a/src/scripts/listPage.ts
+++ b/src/scripts/listPage.ts
@@ -19,7 +19,7 @@ const scheduleIdleTask = (task: () => void): void => {
             window.requestIdleCallback(task, { timeout: 2_000 });
             return;
         }
-        window.setTimeout(task, 1_000);
+        setTimeout(task, 1_000);
     };
 
     if (document.readyState === 'complete') schedule();

--- a/src/scripts/listPage.ts
+++ b/src/scripts/listPage.ts
@@ -4,6 +4,28 @@ import { assetPath, pagePathWithQuery } from '../utils/paths';
 type ListItem = Artist | Character;
 type ListMode = 'character' | 'artist';
 
+type NavigatorWithConnection = Navigator & {
+    connection?: {
+        saveData?: boolean;
+    };
+};
+
+const shouldAvoidSpeculativeFetch = (): boolean =>
+    Boolean((navigator as NavigatorWithConnection).connection?.saveData);
+
+const scheduleIdleTask = (task: () => void): void => {
+    const schedule = (): void => {
+        if ('requestIdleCallback' in window) {
+            window.requestIdleCallback(task, { timeout: 2_000 });
+            return;
+        }
+        window.setTimeout(task, 1_000);
+    };
+
+    if (document.readyState === 'complete') schedule();
+    else window.addEventListener('load', schedule, { once: true });
+};
+
 const initializeListPage = (): void => {
     const root = document.querySelector<HTMLElement>('[data-list-page]');
     if (!root) return;
@@ -164,6 +186,12 @@ const initializeListPage = (): void => {
         visibleCount += pageSize;
         void renderLoadedItems().catch(reportLoadError);
     });
+
+    if (!shouldAvoidSpeculativeFetch()) {
+        scheduleIdleTask(() => {
+            void fetch(assetPath('runtime-data/gallery-posts.json')).catch(() => undefined);
+        });
+    }
 };
 
 initializeListPage();

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -19,6 +19,28 @@ const artists = JSON.parse(
     fs.readFileSync(new URL('../../data/artists.json', import.meta.url), 'utf8')
 ) as Array<{ id: string; name: string }>;
 
+const makeIdleCallbacksImmediate = async (page: import('@playwright/test').Page): Promise<void> => {
+    await page.addInitScript(() => {
+        window.requestIdleCallback = callback => {
+            window.setTimeout(() => callback({
+                didTimeout: false,
+                timeRemaining: () => 50
+            }), 0);
+            return 1;
+        };
+    });
+};
+
+const stubRedditImages = async (page: import('@playwright/test').Page): Promise<void> => {
+    await page.route(/https:\/\/(?:i|preview)\.redd\.it\/.*/, async route => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'image/png',
+            body: Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=', 'base64')
+        });
+    });
+};
+
 test('mobile visitors retain access to primary navigation', async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
     await page.goto('./');
@@ -46,6 +68,43 @@ test('gallery exposes canonical metadata and interactive filtering', async ({ pa
     await contentFilter.click();
     await expect(page.getByRole('button', { name: 'SFW Only' })).toHaveAttribute('aria-pressed', 'true');
     await expect(page.locator('.grid img.nsfw')).toHaveCount(0);
+});
+
+test('character browsing warms gallery runtime data after idle', async ({ page }) => {
+    await makeIdleCallbacksImmediate(page);
+    const warmedData = page.waitForRequest(request =>
+        new URL(request.url()).pathname.endsWith('/runtime-data/gallery-posts.json')
+    );
+
+    await page.goto('characters/', { waitUntil: 'domcontentloaded' });
+    await warmedData;
+});
+
+test('gallery warms a bounded set of visible post documents after primary artwork', async ({ page }) => {
+    await makeIdleCallbacksImmediate(page);
+    await stubRedditImages(page);
+    const warmedPost = page.waitForRequest(request =>
+        request.resourceType() === 'fetch'
+        && /\/posts\/[^/]+\/$/.test(new URL(request.url()).pathname)
+    );
+
+    await page.goto('gallery/', { waitUntil: 'domcontentloaded' });
+    await warmedPost;
+});
+
+test('post pages warm adjacent documents only after primary artwork settles', async ({ page }) => {
+    await makeIdleCallbacksImmediate(page);
+    await stubRedditImages(page);
+    const postId = extractRedditId(posts[0].reddit);
+    expect(postId).not.toBe('');
+    const warmedAdjacent = page.waitForRequest(request =>
+        request.resourceType() === 'fetch'
+        && /\/posts\/[^/]+\/$/.test(new URL(request.url()).pathname)
+    );
+
+    await page.goto(`posts/${postId}/`, { waitUntil: 'domcontentloaded' });
+    await warmedAdjacent;
+    await expect(page.locator('[data-adjacent-post]')).not.toHaveCount(0);
 });
 
 test('a direct post URL returns server-rendered archive metadata and content', async ({ page, request }) => {


### PR DESCRIPTION
Adds conservative intent-aware navigation warming on top of the current native Astro navigation architecture.

- warms `gallery-posts.json` during idle time on Characters/Artists pages so filtered Gallery navigation can render immediately
- warms only the first four visible Gallery post documents after the primary gallery artwork has settled
- warms Previous/Next post documents only after the current post's primary artwork has loaded, avoiding LCP contention
- respects `navigator.connection.saveData` for all speculative requests
- keeps Astro hover-intent prefetch, native document navigation, View Transitions, and the existing service-worker cache model unchanged
- adds Playwright coverage for list → gallery data warming, bounded Gallery post warming, and delayed adjacent-post warming

This deliberately avoids reintroducing ClientRouter or eager viewport-wide prefetching. The goal is to improve the highest-probability next navigation while keeping critical artwork requests first.