### PR TITLE
perf: warm every visible gallery post

### DIFF
--- a/src/scripts/gallery.ts
+++ b/src/scripts/gallery.ts
@@ -10,6 +10,7 @@ type NavigatorWithConnection = Navigator & {
     };
 };
 
+const GALLERY_POSTS_PER_PAGE = 12;
 let postsRequest: Promise<GalleryPost[]> | undefined;
 const warmedPostUrls = new Set<string>();
 
@@ -29,7 +30,7 @@ const warmVisiblePostDocuments = (grid: HTMLElement | null): void => {
 
     scheduleIdleTask(() => {
         const urls = [...grid.querySelectorAll<HTMLAnchorElement>('a.tile')]
-            .slice(0, 4)
+            .slice(0, GALLERY_POSTS_PER_PAGE)
             .map(link => link.href)
             .filter(url => !warmedPostUrls.has(url));
 
@@ -71,7 +72,7 @@ const initializeGallery = (): void => {
     const root = document.querySelector<HTMLElement>('[data-gallery-page]');
     if (!root) return;
 
-    const postsPerPage = 12;
+    const postsPerPage = GALLERY_POSTS_PER_PAGE;
     const grid = root.querySelector<HTMLElement>('[data-gallery-grid]');
     const postCount = root.querySelector<HTMLElement>('[data-post-count]');
     const galleryOnlyButton = root.querySelector<HTMLButtonElement>('[data-gallery-only]');

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -86,16 +86,35 @@ test('character browsing warms gallery runtime data after idle', async ({ page }
     await warmedData;
 });
 
-test('gallery warms a bounded set of visible post documents after primary artwork', async ({ page }) => {
+test('gallery warms all twelve visible post documents on each page', async ({ page }) => {
     await makeIdleCallbacksImmediate(page);
     await stubRedditImages(page);
-    const warmedPost = page.waitForRequest(request =>
-        request.resourceType() === 'fetch'
-        && /\/posts\/[^/]+\/$/.test(new URL(request.url()).pathname)
-    );
+
+    const warmedPostUrls = new Set<string>();
+    page.on('request', request => {
+        if (request.resourceType() === 'fetch' && /\/posts\/[^/]+\/$/.test(new URL(request.url()).pathname)) {
+            warmedPostUrls.add(request.url());
+        }
+    });
 
     await page.goto('gallery/', { waitUntil: 'domcontentloaded' });
-    await warmedPost;
+
+    const firstPageUrls = await page.locator('[data-gallery-grid] a.tile').evaluateAll(links =>
+        links.map(link => (link as HTMLAnchorElement).href)
+    );
+    expect(firstPageUrls).toHaveLength(12);
+    await expect.poll(() => firstPageUrls.every(url => warmedPostUrls.has(url))).toBe(true);
+
+    await page.getByRole('button', { name: '2', exact: true }).click();
+    await expect(page.getByRole('button', { name: '2', exact: true })).toHaveAttribute('aria-current', 'page');
+
+    const secondPageUrls = await page.locator('[data-gallery-grid] a.tile').evaluateAll(links =>
+        links.map(link => (link as HTMLAnchorElement).href)
+    );
+    expect(secondPageUrls).toHaveLength(12);
+    expect(secondPageUrls).not.toEqual(firstPageUrls);
+    await expect.poll(() => secondPageUrls.every(url => warmedPostUrls.has(url))).toBe(true);
+    expect(warmedPostUrls.size).toBe(24);
 });
 
 test('post pages warm related artist documents after primary artwork settles', async ({ page }) => {
@@ -145,8 +164,8 @@ test('a direct post URL returns server-rendered archive metadata and content', a
     expect(rawHtml).toContain(`<title>${artistName} | Touhou Translations</title>`);
     expect(rawHtml).toContain(`<link rel="canonical" href="${canonicalUrl}"`);
     expect(rawHtml).toContain('<meta property="og:type" content="article"');
-    expect(rawHtml).toMatch(/class="[^"]*\bartist-pill\b[^"]*"/);
-    expect(rawHtml).toMatch(/class="[^"]*\bpanel\b[^"]*\bprose\b[^"]*"/);
+    expect(rawHtml).toMatch(/class="[^\"]*\bartist-pill\b[^\"]*"/);
+    expect(rawHtml).toMatch(/class="[^\"]*\bpanel\b[^\"]*\bprose\b[^\"]*"/);
     expect(rawHtml).toContain(post.reddit);
     expect(rawHtml).toContain(post.src);
     expect(rawHtml).toContain(post.url[0]);


### PR DESCRIPTION
Expands Gallery document warming from the first four visible posts to the full 12-post page.

- uses a shared 12-post page constant for both pagination and speculative warming
- warms all visible post HTML documents after the first gallery image settles and the browser becomes idle
- repeats warming after Gallery renders, including pagination/filter/sort changes
- keeps the session-level URL set so previously warmed post documents are not fetched again
- continues to respect Save-Data
- adds Playwright coverage for warming all 12 posts on page 1 and all 12 posts after moving to page 2

This still warms HTML documents only; Gallery artwork loading behavior is unchanged.