### PR TITLE
perf: warm the next random post

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -162,6 +162,12 @@ const resolvedPreconnectOrigins = preconnectOrigins ?? (
         </div>
 
         <script>
+            type NavigatorWithConnection = Navigator & {
+                connection?: {
+                    saveData?: boolean;
+                };
+            };
+
             const baseUrl = import.meta.env.BASE_URL.endsWith('/')
                 ? import.meta.env.BASE_URL
                 : `${import.meta.env.BASE_URL}/`;
@@ -171,6 +177,7 @@ const resolvedPreconnectOrigins = preconnectOrigins ?? (
             const serviceWorkerScope = baseUrl;
 
             let postIdRequest: Promise<string[]> | undefined;
+            let nextRandomPostRequest: Promise<string> | undefined;
             let randomPostLoading = false;
             const randomPostButtons = [...document.querySelectorAll<HTMLButtonElement>('[data-random-post]')];
 
@@ -200,16 +207,52 @@ const resolvedPreconnectOrigins = preconnectOrigins ?? (
                 return postIdRequest;
             };
 
+            const getNextRandomPostUrl = (): Promise<string> => {
+                nextRandomPostRequest ??= fetchRandomPostIds()
+                    .then(postIds => {
+                        if (postIds.length === 0) throw new Error('No posts are available.');
+
+                        const currentUrl = window.location.href;
+                        const candidateUrls = postIds
+                            .map(id => new URL(`${postsBaseUrl}${encodeURIComponent(id)}/`, window.location.origin).href)
+                            .filter(url => url !== currentUrl);
+                        const availableUrls = candidateUrls.length > 0
+                            ? candidateUrls
+                            : postIds.map(id => new URL(`${postsBaseUrl}${encodeURIComponent(id)}/`, window.location.origin).href);
+
+                        return availableUrls[Math.floor(Math.random() * availableUrls.length)];
+                    })
+                    .catch(error => {
+                        nextRandomPostRequest = undefined;
+                        throw error;
+                    });
+
+                return nextRandomPostRequest;
+            };
+
+            const warmNextRandomPost = (): void => {
+                if ((navigator as NavigatorWithConnection).connection?.saveData) return;
+
+                const warm = (): void => {
+                    void getNextRandomPostUrl()
+                        .then(url => fetch(url))
+                        .catch(() => undefined);
+                };
+
+                if ('requestIdleCallback' in window) {
+                    window.requestIdleCallback(warm, { timeout: 2_000 });
+                    return;
+                }
+                setTimeout(warm, 500);
+            };
+
             const goToRandomPost = async (): Promise<void> => {
                 if (randomPostLoading) return;
                 randomPostLoading = true;
                 setRandomPostState('Loading…', true);
 
                 try {
-                    const postIds = await fetchRandomPostIds();
-                    if (postIds.length === 0) throw new Error('No posts are available.');
-                    const id = postIds[Math.floor(Math.random() * postIds.length)];
-                    window.location.assign(`${postsBaseUrl}${encodeURIComponent(id)}/`);
+                    window.location.assign(await getNextRandomPostUrl());
                 } catch (error) {
                     console.error('Unable to open a random post.', error);
                     randomPostLoading = false;
@@ -220,6 +263,9 @@ const resolvedPreconnectOrigins = preconnectOrigins ?? (
             for (const button of randomPostButtons) {
                 button.addEventListener('click', () => void goToRandomPost());
             }
+
+            if (document.readyState === 'complete') warmNextRandomPost();
+            else window.addEventListener('load', warmNextRandomPost, { once: true });
 
             if (import.meta.env.PROD && 'serviceWorker' in navigator) {
                 window.addEventListener('load', () => {

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -61,6 +61,23 @@ test('mobile visitors retain access to primary navigation', async ({ page }) => 
     await expect(page).toHaveURL(/\/touhou-translations\/posts\/[^/]+\/$/);
 });
 
+test('the Post button reuses the random post document warmed after idle', async ({ page }) => {
+    await makeIdleCallbacksImmediate(page);
+
+    const warmedRandomPost = page.waitForRequest(request =>
+        request.resourceType() === 'fetch'
+        && /\/posts\/[^/]+\/$/.test(new URL(request.url()).pathname)
+    );
+
+    await page.goto('./', { waitUntil: 'domcontentloaded' });
+    const warmedUrl = (await warmedRandomPost).url();
+
+    await page.getByRole('navigation', { name: 'Primary navigation' })
+        .getByRole('button', { name: 'Post' })
+        .click();
+    await expect(page).toHaveURL(warmedUrl);
+});
+
 test('gallery exposes canonical metadata and interactive filtering', async ({ page }) => {
     await page.goto('gallery/', { waitUntil: 'domcontentloaded' });
 
@@ -114,7 +131,9 @@ test('gallery warms all twelve visible post documents on each page', async ({ pa
     expect(secondPageUrls).toHaveLength(12);
     expect(secondPageUrls).not.toEqual(firstPageUrls);
     await expect.poll(() => secondPageUrls.every(url => warmedPostUrls.has(url))).toBe(true);
-    expect(warmedPostUrls.size).toBe(24);
+
+    const visiblePageUrls = new Set([...firstPageUrls, ...secondPageUrls]);
+    expect([...visiblePageUrls].filter(url => warmedPostUrls.has(url))).toHaveLength(24);
 });
 
 test('post pages warm related artist documents after primary artwork settles', async ({ page }) => {
@@ -197,6 +216,12 @@ test.describe.serial('service worker runtime caching', () => {
         const missingPath = new URL(missingUrl).pathname;
         const postsPath = new URL('posts/', baseURL).pathname;
         const context = await browser.newContext({ serviceWorkers: 'allow' });
+        await context.addInitScript(() => {
+            Object.defineProperty(navigator, 'connection', {
+                configurable: true,
+                value: { saveData: true }
+            });
+        });
         const page = await context.newPage();
 
         const cachedPostPaths = () => page.evaluate(async pathPrefix => {


### PR DESCRIPTION
Warms one exact random Post destination per document and reuses that same candidate when the global Post button is clicked.

- selects and memoizes one random post URL after loading `post-ids.json`
- warms that HTML document after window load and browser idle
- makes the Post button navigate to the already-selected candidate instead of rolling again
- excludes the current Post URL when another destination is available
- respects Save-Data
- keeps speculative warming to one HTML document; artwork behavior is unchanged
- adds Playwright coverage that verifies the warmed URL is the URL the Post button opens
- updates Gallery warming coverage so the global random warm does not pollute its visible-page assertions
- suppresses speculative random warming only inside the service-worker isolation test so its empty-cache premise remains deterministic