### PR TITLE
Optimize profile gallery navigation

### DIFF
--- a/src/components/list/ProfileCard.astro
+++ b/src/components/list/ProfileCard.astro
@@ -1,6 +1,6 @@
 ---
 import type { Artist, Character, PortraitImage } from '../../types/data';
-import { pagePathWithQuery } from '../../utils/paths';
+import { pagePath } from '../../utils/paths';
 import { PORTRAIT_SIZES } from '../../lib/server/portraitImages';
 
 interface Props {
@@ -13,7 +13,7 @@ const { item, mode, portraitImage } = Astro.props;
 const description2 = mode === 'character'
     ? `${(item as Character).artistCount} artist${(item as Character).artistCount === 1 ? '' : 's'}`
     : `${(item as Artist).characterCount} character${(item as Artist).characterCount === 1 ? '' : 's'}`;
-const href = pagePathWithQuery('gallery', `${mode === 'character' ? 'characters' : 'artist'}=${encodeURIComponent(item.id)}`);
+const href = pagePath(`gallery/${mode === 'character' ? 'characters' : 'artists'}/${item.id}`);
 ---
 
 <li class="profile-item large" aria-label={`Profile: ${item.name}`} data-item-id={item.id}>

--- a/src/pages/gallery/artists/[id].astro
+++ b/src/pages/gallery/artists/[id].astro
@@ -1,0 +1,35 @@
+---
+import GalleryBrowser from '../../../components/gallery/GalleryBrowser.astro';
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+import { fetchArtistsData, fetchGalleryData } from '../../../utils/generatedData';
+import { absoluteSiteUrl } from '../../../utils/siteMetadata';
+
+export async function getStaticPaths() {
+    const [{ artists }, { posts }] = await Promise.all([
+        fetchArtistsData(),
+        fetchGalleryData()
+    ]);
+
+    return artists.map(artist => ({
+        params: { id: artist.id },
+        props: {
+            artist,
+            posts: posts.filter(post => post.artistId === artist.id)
+        }
+    }));
+}
+
+const { artist, posts } = Astro.props;
+const title = `${artist.name} Gallery | Touhou Translations`;
+const description = `Browse English-translated Touhou Project comics and illustrations by ${artist.name}.`;
+---
+
+<BaseLayout
+    {title}
+    {description}
+    canonical={absoluteSiteUrl(`gallery/artists/${artist.id}`)}
+    ogTitle={title}
+    currentSection="gallery"
+>
+    <GalleryBrowser {posts} />
+</BaseLayout>

--- a/src/pages/gallery/characters/[id].astro
+++ b/src/pages/gallery/characters/[id].astro
@@ -1,0 +1,35 @@
+---
+import GalleryBrowser from '../../../components/gallery/GalleryBrowser.astro';
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+import { fetchCharactersData, fetchGalleryData } from '../../../utils/generatedData';
+import { absoluteSiteUrl } from '../../../utils/siteMetadata';
+
+export async function getStaticPaths() {
+    const [{ characters }, { posts }] = await Promise.all([
+        fetchCharactersData(),
+        fetchGalleryData()
+    ]);
+
+    return characters.map(character => ({
+        params: { id: character.id },
+        props: {
+            character,
+            posts: posts.filter(post => post.characterIds.includes(character.id))
+        }
+    }));
+}
+
+const { character, posts } = Astro.props;
+const title = `${character.name} Gallery | Touhou Translations`;
+const description = `Browse English-translated Touhou Project comics and illustrations featuring ${character.name}.`;
+---
+
+<BaseLayout
+    {title}
+    {description}
+    canonical={absoluteSiteUrl(`gallery/characters/${character.id}`)}
+    ogTitle={title}
+    currentSection="gallery"
+>
+    <GalleryBrowser {posts} />
+</BaseLayout>

--- a/src/scripts/gallery.ts
+++ b/src/scripts/gallery.ts
@@ -68,6 +68,21 @@ const loadPosts = (): Promise<GalleryPost[]> => {
     return postsRequest;
 };
 
+const staticGalleryFilter = (): { characterIds: string[]; artistIds: string[] } => {
+    const segments = window.location.pathname.split('/').filter(Boolean);
+    const galleryIndex = segments.lastIndexOf('gallery');
+    if (galleryIndex < 0) return { characterIds: [], artistIds: [] };
+
+    const kind = segments[galleryIndex + 1];
+    const id = segments[galleryIndex + 2];
+    if (!id) return { characterIds: [], artistIds: [] };
+
+    const decodedId = decodeURIComponent(id);
+    if (kind === 'characters') return { characterIds: [decodedId], artistIds: [] };
+    if (kind === 'artists') return { characterIds: [], artistIds: [decodedId] };
+    return { characterIds: [], artistIds: [] };
+};
+
 const initializeGallery = (): void => {
     const root = document.querySelector<HTMLElement>('[data-gallery-page]');
     if (!root) return;
@@ -79,12 +94,15 @@ const initializeGallery = (): void => {
     const dateSortButton = root.querySelector<HTMLButtonElement>('[data-date-sort]');
     const pagination = root.querySelector<HTMLElement>('[data-pagination]');
     const search = new URLSearchParams(window.location.search);
+    const staticFilter = staticGalleryFilter();
 
     let currentPage = 1;
     let dateSort: SortOrder = 'desc';
     let galleryOnly = false;
     const characterQueries = (search.get('characters') || '').split(',').map(value => value.trim()).filter(Boolean);
     const artistQueries = (search.get('artist') || search.get('artists') || '').split(',').map(value => value.trim()).filter(Boolean);
+    if (characterQueries.length === 0) characterQueries.push(...staticFilter.characterIds);
+    if (artistQueries.length === 0) artistQueries.push(...staticFilter.artistIds);
     const mode: 'and' | 'or' = search.get('mode') === 'or' ? 'or' : 'and';
     let openJump: JumpItem | null = null;
     let jumpPage = '';
@@ -249,7 +267,8 @@ const initializeGallery = (): void => {
         }).catch(reportLoadError);
     });
 
-    if (characterQueries.length > 0 || artistQueries.length > 0 || search.has('mode')) {
+    const hasQueryFilter = search.has('characters') || search.has('artist') || search.has('artists') || search.has('mode');
+    if (hasQueryFilter) {
         void render().catch(reportLoadError);
     } else {
         warmInitialPostDocuments(grid);

--- a/src/scripts/listPage.ts
+++ b/src/scripts/listPage.ts
@@ -1,30 +1,8 @@
 import type { Artist, Character, SortOrder } from '../types/data';
-import { assetPath, pagePathWithQuery } from '../utils/paths';
+import { assetPath, pagePath, pagePathWithQuery } from '../utils/paths';
 
 type ListItem = Artist | Character;
 type ListMode = 'character' | 'artist';
-
-type NavigatorWithConnection = Navigator & {
-    connection?: {
-        saveData?: boolean;
-    };
-};
-
-const shouldAvoidSpeculativeFetch = (): boolean =>
-    Boolean((navigator as NavigatorWithConnection).connection?.saveData);
-
-const scheduleIdleTask = (task: () => void): void => {
-    const schedule = (): void => {
-        if ('requestIdleCallback' in window) {
-            window.requestIdleCallback(task, { timeout: 2_000 });
-            return;
-        }
-        setTimeout(task, 1_000);
-    };
-
-    if (document.readyState === 'complete') schedule();
-    else window.addEventListener('load', schedule, { once: true });
-};
 
 const initializeListPage = (): void => {
     const root = document.querySelector<HTMLElement>('[data-list-page]');
@@ -80,11 +58,9 @@ const initializeListPage = (): void => {
         return sortOrder === 'asc' ? leftSecondary - rightSecondary : rightSecondary - leftSecondary;
     };
 
-    const selectedGalleryUrl = (id: string): string => {
-        const key = mode === 'character' ? 'characters' : 'artist';
-        const value = mode === 'character' ? selectedItems.join(',') || id : id;
-        return pagePathWithQuery('gallery', `${key}=${encodeURIComponent(value)}`);
-    };
+    const selectedGalleryUrl = (id: string): string => (
+        pagePath(`gallery/${mode === 'character' ? 'characters' : 'artists'}/${id}`)
+    );
 
     const makeText = (className: string, value: string): HTMLParagraphElement => {
         const paragraph = document.createElement('p');
@@ -194,12 +170,6 @@ const initializeListPage = (): void => {
         visibleCount += pageSize;
         void renderLoadedItems().catch(reportLoadError);
     });
-
-    if (!shouldAvoidSpeculativeFetch()) {
-        scheduleIdleTask(() => {
-            void fetch(assetPath('runtime-data/gallery-posts.json')).catch(() => undefined);
-        });
-    }
 };
 
 initializeListPage();

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -93,14 +93,27 @@ test('gallery exposes canonical metadata and interactive filtering', async ({ pa
     await expect(page.locator('.grid img.nsfw')).toHaveCount(0);
 });
 
-test('character browsing warms gallery runtime data after idle', async ({ page }) => {
-    await makeIdleCallbacksImmediate(page);
-    const warmedData = page.waitForRequest(request =>
-        new URL(request.url()).pathname.endsWith('/runtime-data/gallery-posts.json')
-    );
+test('profile browsing navigates directly to static filtered galleries', async ({ page }) => {
+    const galleryDataRequests: string[] = [];
+    page.on('request', request => {
+        if (new URL(request.url()).pathname.endsWith('/runtime-data/gallery-posts.json')) {
+            galleryDataRequests.push(request.url());
+        }
+    });
 
     await page.goto('characters/', { waitUntil: 'domcontentloaded' });
-    await warmedData;
+    const characterLink = page.locator('[data-list-grid] a.box').first();
+    await expect(characterLink).toHaveAttribute('href', /\/gallery\/characters\/[^/]+\/$/);
+    await characterLink.click();
+    await expect(page).toHaveURL(/\/touhou-translations\/gallery\/characters\/[^/]+\/$/);
+    expect(galleryDataRequests).toEqual([]);
+
+    await page.goto('artists/', { waitUntil: 'domcontentloaded' });
+    const artistLink = page.locator('[data-list-grid] a.box').first();
+    await expect(artistLink).toHaveAttribute('href', /\/gallery\/artists\/[^/]+\/$/);
+    await artistLink.click();
+    await expect(page).toHaveURL(/\/touhou-translations\/gallery\/artists\/[^/]+\/$/);
+    expect(galleryDataRequests).toEqual([]);
 });
 
 test('gallery warms all twelve visible post documents on each page', async ({ page }) => {


### PR DESCRIPTION
## Summary
- add statically generated gallery routes for individual characters and artists
- navigate profile cards directly to those filtered routes instead of query-filtering the main gallery after load
- preserve the static character/artist filter when gallery controls load runtime data
- remove speculative full gallery-data fetching from character/artist list pages
- keep query-string filtering for multi-select and arbitrary filter combinations
- update end-to-end coverage for direct static profile gallery navigation

## Why
Character and artist navigation previously loaded the unfiltered gallery first, then fetched the full gallery runtime dataset and replaced the initial grid client-side. These routes render the correct filtered gallery in the initial HTML instead.